### PR TITLE
Better handling of backtraces

### DIFF
--- a/example/QCheck_ounit_test.ml
+++ b/example/QCheck_ounit_test.ml
@@ -10,8 +10,17 @@ let failing =
     QCheck.(list small_int)
     (fun l -> l = List.sort compare l);;
 
+exception Error
+
+let error =
+  QCheck.Test.make ~count:10
+    ~name:"error_raise_exn"
+    QCheck.int
+    (fun _ -> raise Error)
+
 let () =
+  Printexc.record_backtrace true;
   let open OUnit2 in
   run_test_tt_main
     ("tests" >:::
-       List.map QCheck_runner.to_ounit2_test [passing; failing])
+     List.map QCheck_runner.to_ounit2_test [passing; failing; error])

--- a/src/QCheck.ml
+++ b/src/QCheck.ml
@@ -744,7 +744,7 @@ module Test = struct
     | Success
     | Failure
     | FalseAssumption
-    | Error of exn
+    | Error of exn * string
 
   (* Step function, called after each instance test *)
   type 'a step = string -> 'a cell -> 'a -> res -> unit
@@ -811,7 +811,7 @@ module Test = struct
     (* first, shrink
        TODO: shall we shrink differently (i.e. expected only an error)? *)
     let input, steps = shrink state input in
-    state.step state.test.name state.test input (Error e);
+    state.step state.test.name state.test input (Error (e, bt));
     R.error state.res ~steps input e bt;
     CR_yield state.res
 

--- a/src/QCheck.ml
+++ b/src/QCheck.ml
@@ -653,7 +653,8 @@ module TestResult = struct
   type 'a state =
     | Success
     | Failed of 'a failed_state (** Failed instances *)
-    | Error of 'a counter_ex * exn  (** Error, and instance that triggered it *)
+    | Error of 'a counter_ex * exn * string (** Error, backtrace, and instance
+                                                that triggered it *)
 
   (* result returned by running a test *)
   type 'a t = {
@@ -668,8 +669,8 @@ module TestResult = struct
     let c_ex = {instance; shrink_steps; } in
     match res.state with
     | Success -> res.state <- Failed [ c_ex ]
-    | Error (x, e) ->
-        res.state <- Error (x,e); (* same *)
+    | Error (x, e, bt) ->
+        res.state <- Error (x,e,bt); (* same *)
     | Failed [] -> assert false
     | Failed (c_ex' :: _ as l) ->
         match small with
@@ -687,8 +688,8 @@ module TestResult = struct
             res.state <-
               Failed (c_ex :: l)
 
-  let error ~steps res instance e =
-    res.state <- Error ({instance; shrink_steps=steps}, e)
+  let error ~steps res instance e bt =
+    res.state <- Error ({instance; shrink_steps=steps}, e, bt)
 end
 
 module Test = struct
@@ -806,12 +807,12 @@ module Test = struct
     | CR_yield of 'a TestResult.t
 
   (* test raised [e] on [input]; try to shrink then fail *)
-  let handle_exn state input e : _ check_result =
+  let handle_exn state input e bt : _ check_result =
     (* first, shrink
        TODO: shall we shrink differently (i.e. expected only an error)? *)
     let input, steps = shrink state input in
     state.step state.test.name state.test input (Error e);
-    R.error state.res ~steps input e;
+    R.error state.res ~steps input e bt;
     CR_yield state.res
 
   (* test failed on [input], which means the law is wrong. Continue if
@@ -851,7 +852,9 @@ module Test = struct
         | FailedPrecondition ->
           state.step state.test.name state.test input FalseAssumption;
           CR_continue
-        | e -> handle_exn state input e
+        | e ->
+          let bt = Printexc.get_backtrace () in
+          handle_exn state input e bt
       in
       match res with
         | CR_continue -> check_state state
@@ -929,9 +932,8 @@ module Test = struct
 
   let check_result cell res = match res.R.state with
     | R.Success -> ()
-    | R.Error (i,e) ->
-      let st = Printexc.get_backtrace () in
-      raise (Test_error (cell.name, print_c_ex cell.arb i, e, st))
+    | R.Error (i,e, bt) ->
+      raise (Test_error (cell.name, print_c_ex cell.arb i, e, bt))
     | R.Failed l ->
         let l = List.map (print_c_ex cell.arb) l in
         raise (Test_fail (cell.name, l))

--- a/src/QCheck.mli
+++ b/src/QCheck.mli
@@ -557,7 +557,7 @@ module Test : sig
     | Success
     | Failure
     | FalseAssumption
-    | Error of exn
+    | Error of exn * string
 
   type 'a step = string -> 'a cell -> 'a -> res -> unit
   (** Callback executed after each instance of a test has been run.

--- a/src/QCheck.mli
+++ b/src/QCheck.mli
@@ -472,7 +472,8 @@ module TestResult : sig
   type 'a state =
     | Success
     | Failed of 'a failed_state (** Failed instances *)
-    | Error of 'a counter_ex * exn  (** Error, and instance that triggered it *)
+    | Error of 'a counter_ex * exn * string (** Error, backtrace, and instance
+                                                that triggered it *)
 
   (* result returned by running a test *)
   type 'a t = {

--- a/src/QCheck_runner.ml
+++ b/src/QCheck_runner.ml
@@ -256,8 +256,8 @@ let callback ~verbose ~print_res ~print name cell result =
       | R.Success -> ()
       | R.Failed l ->
         print.fail "\r  %s\n" (T.print_fail arb name l);
-      | R.Error (i,e) ->
-        print.err "\r  %s\n" (T.print_error arb name (i,e));
+      | R.Error (i,e,st) ->
+        print.err "\r  %s\n" (T.print_error ~st arb name (i,e));
   )
 
 let name_of_cell cell =

--- a/src/QCheck_runner.ml
+++ b/src/QCheck_runner.ml
@@ -109,6 +109,7 @@ let parse_cli ~full_options argv =
   let print_list = ref false in
   let set_verbose () = set_verbose true in
   let set_long_tests () = set_long_tests true in
+  let set_backtraces () = Printexc.record_backtrace true in
   let set_list () = print_list := true in
   let slow = ref 0 in
   let options = Arg.align (
@@ -124,6 +125,7 @@ let parse_cli ~full_options argv =
     [ "-s", Arg.Set_int seed, " "
     ; "--seed", Arg.Set_int seed, " set random seed (to repeat tests)"
     ; "--long", Arg.Unit set_long_tests, " run long tests"
+    ; "-bt", Arg.Unit set_backtraces, " enable backtraces"
     ]
   ) in
   Arg.parse_argv argv options (fun _ ->()) "run qtest suite";


### PR DESCRIPTION
This patch record the backtraces of exceptions raised during a test, so that it can be printed afterward.

Consider the following file foo.ml:
```ocaml
exception Error

let f i =
  raise Error

let test = QCheck.(Test.make int f)

let () =
  QCheck_runner.run_tests_main [test]
```

Once compiled the results are the following.
Before patch:
```
$ OCAMLRUNPARAM=b ./foo.native 
random seed: 133695414
  test `anon_test_1` raised exception `Foo.Error`
on `0 (after 62 shrink steps)`
failure (1 tests failed, ran 1 tests)
```

After patch:
```
$ OCAMLRUNPARAM=b ./foo.native 
random seed: 502100165
  test `anon_test_1` raised exception `Foo.Error`
on `0 (after 61 shrink steps)`
Raised at file "foo.ml", line 5, characters 8-13
Called from file "src/QCheck.ml", line 844, characters 13-33

failure (1 tests failed, ran 1 tests)
```