### PR TITLE
Add Test.get_count on test cells

### DIFF
--- a/src/QCheck.ml
+++ b/src/QCheck.ml
@@ -710,6 +710,8 @@ module Test = struct
   let get_law {law; _} = law
   let get_arbitrary {arb; _} = arb
 
+  let get_count {count; _ } = count
+
   let default_count = 100
 
   let fresh_name =

--- a/src/QCheck.mli
+++ b/src/QCheck.mli
@@ -514,6 +514,7 @@ module Test : sig
   val get_law : 'a cell -> ('a -> bool)
   val get_name : _ cell -> string
   val set_name : _ cell -> string -> unit
+  val get_count : _ cell -> int
 
   type t = Test : 'a cell -> t
   (** Same as ['a cell], but masking the type parameter. This allows to


### PR DESCRIPTION
Accessing the number of tests to run would be interesting for writing `step` functions.