### PR TITLE
Adjust integer size printing in qcheck_runner

### DIFF
--- a/example/QCheck_runner_test.ml
+++ b/example/QCheck_runner_test.ml
@@ -1,6 +1,6 @@
 
 let passing =
-  QCheck.Test.make ~count:1000 ~long_factor:2
+  QCheck.Test.make ~count:100 ~long_factor:100
     ~name:"list_rev_is_involutive"
     QCheck.(list small_int)
     (fun l -> List.rev (List.rev l) = l);;
@@ -20,7 +20,7 @@ let error =
     (fun _ -> raise Error)
 
 let collect =
-  QCheck.Test.make ~count:1000
+  QCheck.Test.make ~count:100 ~long_factor:100
     ~name:"collect_results"
     QCheck.(make ~collect:string_of_int (Gen.int_bound 4))
     (fun _ -> true)

--- a/src/QCheck_runner.mli
+++ b/src/QCheck_runner.mli
@@ -152,7 +152,7 @@ val run_tests_main : ?argv:string array -> QCheck.Test.t list -> 'a
     Below is an example of the output of the [run_tests] and [run_tests_main]
     function: {v
 random seed: 438308050
-generated  error;  fail; pass / total       time -- test name
+generated  error;  fail; pass / total -     time -- test name
 [✓] (1000)    0 ;    0 ; 1000 / 1000 --     0.5s -- list_rev_is_involutive
 [✗] (   1)    0 ;    1 ;    0 /   10 --     0.0s -- should_fail_sort_id
 [✗] (   1)    1 ;    0 ;    0 /   10 --     0.0s -- should_error_raise_exn


### PR DESCRIPTION
The previous implementation assumed a maximum size of 4 for integer printing of integers in order to keep a correct alignment of columns. This pull request dynamically computes the required size for printing integers so that everything lines up nicely.
The number of test instances and long factors in `example/QCheck_runner_test.ml` have been updated to test different sizes.

Examples of previous outputs:
```
generated  error;  fail; pass / total       time -- test name
[✓] ( 100)    0 ;    0 ;  100 /  100 --     0.1s -- list_rev_is_involutive
[✗] (   2)    0 ;    1 ;    1 /   10 --     0.0s -- should_fail_sort_id
[✗] (   1)    1 ;    0 ;    0 /   10 --     0.0s -- should_error_raise_exn
[✓] ( 100)    0 ;    0 ;  100 /  100 --     0.0s -- collect_results
```
```
generated  error;  fail; pass / total       time -- test name
[✓] (10000)    0 ;    0 ; 10000 / 10000 --     3.9s -- list_rev_is_involutive
[✗] (   1)    0 ;    1 ;    0 /   10 --     0.0s -- should_fail_sort_id
[✗] (   1)    1 ;    0 ;    0 /   10 --     0.0s -- should_error_raise_exn
[✓] (10000)    0 ;    0 ; 10000 / 10000 --     0.2s -- collect_results
```

Now it looks like:
```
generated; error;  fail; pass / total -     time -- test name
[✓] ( 100)    0 ;    0 ;  100 /  100 --     0.0s -- list_rev_is_involutive
[✗] (   1)    0 ;    1 ;    0 /   10 --     0.0s -- should_fail_sort_id
[✗] (   1)    1 ;    0 ;    0 /   10 --     0.0s -- should_error_raise_exn
[✓] ( 100)    0 ;    0 ;  100 /  100 --     0.0s -- collect_results
```
```
 generated;  error;   fail;  pass /  total -     time -- test name
[✓] (10000)     0 ;     0 ; 10000 / 10000 --     3.8s -- list_rev_is_involutive
[✗] (    1)     0 ;     1 ;     0 /    10 --     0.0s -- should_fail_sort_id
[✗] (    1)     1 ;     0 ;     0 /    10 --     0.0s -- should_error_raise_exn
[✓] (10000)     0 ;     0 ; 10000 / 10000 --     0.2s -- collect_results

```