### PR TITLE
Change Gen.int_bount/int_range to support up to 2^62 / max_int

### DIFF
--- a/src/QCheck.ml
+++ b/src/QCheck.ml
@@ -141,10 +141,12 @@ module Gen = struct
   let int st = if RS.bool st then - (pint st) - 1 else pint st
   let int_bound n =
     assert (n >= 0);
-    fun st -> Random.State.int st (n+1)
+    fun st ->
+      let r = pint st in
+      r mod (n+1)
   let int_range a b =
     assert (b >= a);
-    fun st -> a + (Random.State.int st (b-a+1))
+    fun st -> a + (int_bound (b-a) st)
   let (--) = int_range
 
   (* NOTE: we keep this alias to not break code that uses [small_int]


### PR DESCRIPTION
This is an attempt at lifting the 2^30 restriction of PR #7 to something bigger on 64-bit machines.
It works by reusing `pint` which already handles the uniform glueing of 30-bit chunks.

Limitation: it should work up to `max_int` (2^62 on my 64-bit machine) as argument to `Gen.int_bound`.
But it is limited to intervals of length `max_int` as arguments to `Gen.int_range`. 
As a consequence generating test input with `Gen.int_range 0 max_int` and `Gen.int_range min_int (-1)` works, but `Gen.int_range (-1) max_int` and `Gen.int_range min_int 0` will fail as these intervals are just one greater than `max_int` in length.

Is it uniform?
Since `pint` is already supposed to provide uniform bit-patterns, and `Gen.int_range` just calls `Gen.int_bound` it is a question of whether `Gen.int_bound` uses the uniform bit-patterns to create uniformly distributed output. For arguments that are powers of 2 - 1, this should be obvious: such numbers are represented by a bit string of some fixed length, all with equal chance. For example, here is the distribution of 1.000.000 numbers represented by 3 bits:
```
# let t = Test.make ~count:1_000_000 (make ~collect:string_of_int (Gen.int_bound 7)) (fun _ -> true);;
# QCheck_runner.run_tests [t];;               

+++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

Collect results for test anon_test_8:

7: 124751 cases
6: 124790 cases
4: 125215 cases
5: 125281 cases
3: 124947 cases
2: 124768 cases
1: 124807 cases
0: 125441 cases
```

The interesting question is then whether the simple `mod` will create non-uniform distributions for arguments that don't fit this pattern. No, apparently not:
```
# let t = Test.make ~count:1_000_000 (make ~collect:string_of_int (Gen.int_bound 5)) (fun _ -> true);;
val t : QCheck.Test.t = QCheck.Test.Test <abstr>
# QCheck_runner.run_tests [t];;                                         

+++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

Collect results for test anon_test_9:

4: 167495 cases
5: 167039 cases
3: 166462 cases
2: 166755 cases
1: 166163 cases
0: 166086 cases
```
which is significantly differently distributed than what we observe if me merely ask for a power-of-two - 1 and collapse some of the bit pattern to the same category:
```
# let t = Test.make ~count:1_000_000 (make ~collect:(fun i -> string_of_int (i mod 6)) (Gen.int_bound 7)) (fun _ -> true);;
val t : QCheck.Test.t = QCheck.Test.Test <abstr>
# QCheck_runner.run_tests [t];;                                         

+++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

Collect results for test anon_test_10:

4: 124982 cases
5: 125058 cases
3: 124912 cases
2: 125374 cases
1: 249681 cases
0: 249993 cases
```