### PR TITLE
Change asserts to raise Invalid_arg (following the doc), and update doc

### DIFF
--- a/src/QCheck.ml
+++ b/src/QCheck.ml
@@ -140,13 +140,17 @@ module Gen = struct
 
   let int st = if RS.bool st then - (pint st) - 1 else pint st
   let int_bound n =
-    assert (n >= 0);
-    fun st ->
-      let r = pint st in
-      r mod (n+1)
+    if n < 0
+    then invalid_arg "Gen.int_bound"
+    else
+      fun st ->
+	let r = pint st in
+	r mod (n+1)
   let int_range a b =
-    assert (b >= a);
-    fun st -> a + (int_bound (b-a) st)
+    if b < a
+    then invalid_arg "Gen.int_range"
+    else
+      fun st -> a + (int_bound (b-a) st)
   let (--) = int_range
 
   (* NOTE: we keep this alias to not break code that uses [small_int]

--- a/src/QCheck.ml
+++ b/src/QCheck.ml
@@ -140,17 +140,13 @@ module Gen = struct
 
   let int st = if RS.bool st then - (pint st) - 1 else pint st
   let int_bound n =
-    if n < 0
-    then invalid_arg "Gen.int_bound"
-    else
-      fun st ->
-	let r = pint st in
-	r mod (n+1)
+    if n < 0 then invalid_arg "Gen.int_bound";
+    fun st ->
+      let r = pint st in
+      r mod (n+1)
   let int_range a b =
-    if b < a
-    then invalid_arg "Gen.int_range"
-    else
-      fun st -> a + (int_bound (b-a) st)
+    if b < a then invalid_arg "Gen.int_range";
+    fun st -> a + (int_bound (b-a) st)
   let (--) = int_range
 
   (* NOTE: we keep this alias to not break code that uses [small_int]

--- a/src/QCheck.mli
+++ b/src/QCheck.mli
@@ -229,11 +229,11 @@ module Gen : sig
 
   val int_bound : int -> int t
   (** Uniform integer generator producing integers within [0... bound].
-      @raise Invalid_argument if the bound is too high (typically 2^30) *)
+      @raise Invalid_argument if the argument is negative *)
 
   val int_range : int -> int -> int t
-  (** Uniform integer generator producing integers within [low,high]
-      @raise Invalid_argument if the range is too large (typically 2^30) *)
+  (** Uniform integer generator producing integers within [low,high].
+      @raise Invalid_argument if [low > high] or if the range is larger than [max_int] *)
 
   val (--) : int -> int -> int t (** Synonym to {!int_range} *)
 


### PR DESCRIPTION
Cleanup #28 to still raise `Invalid_arg` on illegal arguments (as the API doc promises).
Also update the .mli file to reflect the loosened restrictions.