### PR TITLE
Better progress feedback in verbose mode

### DIFF
--- a/src/QCheck.ml
+++ b/src/QCheck.ml
@@ -1142,7 +1142,7 @@ module Test = struct
     | Generating
     | Collecting of 'a
     | Testing of 'a
-    | Shrinked of int * 'a
+    | Shrunk of int * 'a
     | Shrinking of int * int * 'a
 
   type 'a handler = string -> 'a cell -> 'a event -> unit
@@ -1194,7 +1194,7 @@ module Test = struct
      shrinked value and number of steps *)
   let shrink st i =
     let rec shrink_ st i ~steps =
-      st.handler st.test.name st.test (Shrinked (steps, i));
+      st.handler st.test.name st.test (Shrunk (steps, i));
       match st.test.arb.shrink with
       | None -> i, steps
       | Some f ->

--- a/src/QCheck.ml
+++ b/src/QCheck.ml
@@ -1142,7 +1142,8 @@ module Test = struct
     | Generating
     | Collecting of 'a
     | Testing of 'a
-    | Shrinking of int * 'a
+    | Shrinked of int * 'a
+    | Shrinking of int * int * 'a
 
   type 'a handler = string -> 'a cell -> 'a event -> unit
 
@@ -1193,13 +1194,16 @@ module Test = struct
      shrinked value and number of steps *)
   let shrink st i =
     let rec shrink_ st i ~steps =
-      st.handler st.test.name st.test (Shrinking (steps, i));
+      st.handler st.test.name st.test (Shrinked (steps, i));
       match st.test.arb.shrink with
       | None -> i, steps
       | Some f ->
+        let count = ref 0 in
         let i' = Iter.find
           (fun x ->
             try
+              incr count;
+              st.handler st.test.name st.test (Shrinking (steps, !count, x));
               not (st.test.law x)
             with FailedPrecondition | No_example_found _ -> false
             | _ -> true (* fail test (by error) *)

--- a/src/QCheck.mli
+++ b/src/QCheck.mli
@@ -685,7 +685,8 @@ module Test : sig
     | Generating
     | Collecting of 'a
     | Testing of 'a
-    | Shrinking of int * 'a
+    | Shrinked of int * 'a
+    | Shrinking of int * int * 'a
 
   type 'a handler = string -> 'a cell -> 'a event -> unit
   (** Handler executed after each event during testing of an instance. *)

--- a/src/QCheck.mli
+++ b/src/QCheck.mli
@@ -685,7 +685,7 @@ module Test : sig
     | Generating
     | Collecting of 'a
     | Testing of 'a
-    | Shrinked of int * 'a
+    | Shrunk of int * 'a
     | Shrinking of int * int * 'a
 
   type 'a handler = string -> 'a cell -> 'a event -> unit

--- a/src/QCheck.mli
+++ b/src/QCheck.mli
@@ -681,6 +681,15 @@ module Test : sig
     | FalseAssumption
     | Error of exn * string
 
+  type 'a event =
+    | Generating
+    | Collecting of 'a
+    | Testing of 'a
+    | Shrinking of int * 'a
+
+  type 'a handler = string -> 'a cell -> 'a event -> unit
+  (** Handler executed after each event during testing of an instance. *)
+
   type 'a step = string -> 'a cell -> 'a -> res -> unit
   (** Callback executed after each instance of a test has been run.
       The callback is given the instance tested, and the current results
@@ -691,7 +700,8 @@ module Test : sig
       [f name cell res] means test [cell], named [name], gave [res]. *)
 
   val check_cell :
-    ?long:bool -> ?call:'a callback -> ?step:'a step ->
+    ?long:bool -> ?call:'a callback ->
+    ?step:'a step -> ?handler:'a handler ->
     ?rand:Random.State.t -> 'a cell -> 'a TestResult.t
   (** [check_cell ~long ~rand test] generates up to [count] random
       values of type ['a] using [arbitrary] and the random state [st]. The

--- a/src/QCheck_runner.ml
+++ b/src/QCheck_runner.ml
@@ -397,11 +397,12 @@ let pp_counter ~size out c =
     size c.gen size c.errored size c.failed
     size c.passed size c.expected t
 
+
 let handler ~size ~out ~verbose c name _ r =
   let st = function
-    | QCheck.Test.Generating -> "generating"
-    | QCheck.Test.Collecting _ -> "collecting"
-    | QCheck.Test.Testing _ -> "testing"
+    | QCheck.Test.Generating    -> "generating"
+    | QCheck.Test.Collecting _  -> "collecting"
+    | QCheck.Test.Testing _     -> "   testing"
     | QCheck.Test.Shrinking (i, _) ->
       Printf.sprintf "shrinking: %4d" i
   in
@@ -411,7 +412,7 @@ let handler ~size ~out ~verbose c name _ r =
 
 
 let step ~size ~out ~verbose c name _ _ r =
-  let empty_line = String.make 20 ' ' in
+  let empty_line = String.make 100 ' ' in
   let aux = function
     | QCheck.Test.Success -> c.passed <- c.passed + 1
     | QCheck.Test.Failure -> c.failed <- c.failed + 1
@@ -420,11 +421,11 @@ let step ~size ~out ~verbose c name _ _ r =
   in
   c.gen <- c.gen + 1;
   aux r;
+  (* the empty_line string is useful to clear the state
+     previously printed by the handler *)
   if verbose then
-    (* the 'empty_line' string is useful to clear the state
-       previously printed by the handler *)
-    Printf.fprintf out "\r[ ] %a -- %s%s%!"
-      (pp_counter ~size) c name empty_line
+    Printf.fprintf out "\r%s\r[ ] %a -- %s%!"
+      empty_line (pp_counter ~size) c name
 
 let callback ~size ~out ~verbose ~colors c name _ _ =
   let pass = c.failed = 0 && c.errored = 0 in

--- a/src/QCheck_runner.ml
+++ b/src/QCheck_runner.ml
@@ -478,6 +478,9 @@ let run_tests
       start; expected; gen = 0;
       passed = 0; failed = 0; errored = 0;
     } in
+    if verbose then
+      Printf.fprintf out "\r[ ] %a -- %s%!"
+        (pp_counter ~size) c (T.get_name cell);
     let r = QCheck.Test.check_cell ~long ~rand
         ~step:(step ~size ~out ~verbose c)
         ~call:(callback ~size ~out ~verbose ~colors c)

--- a/src/QCheck_runner.ml
+++ b/src/QCheck_runner.ml
@@ -403,8 +403,10 @@ let handler ~size ~out ~verbose c name _ r =
     | QCheck.Test.Generating    -> "generating"
     | QCheck.Test.Collecting _  -> "collecting"
     | QCheck.Test.Testing _     -> "   testing"
-    | QCheck.Test.Shrinking (i, _) ->
+    | QCheck.Test.Shrinked (i, _) ->
       Printf.sprintf "shrinking: %4d" i
+    | QCheck.Test.Shrinking (i, j, _) ->
+      Printf.sprintf "shrinking: %4d.%04d" i j
   in
   if verbose then
     Printf.fprintf out "\r[ ] %a -- %s (%s)%!"
@@ -412,7 +414,7 @@ let handler ~size ~out ~verbose c name _ r =
 
 
 let step ~size ~out ~verbose c name _ _ r =
-  let empty_line = String.make 100 ' ' in
+  let empty_line = String.make 140 ' ' in
   let aux = function
     | QCheck.Test.Success -> c.passed <- c.passed + 1
     | QCheck.Test.Failure -> c.failed <- c.failed + 1

--- a/src/QCheck_runner.ml
+++ b/src/QCheck_runner.ml
@@ -403,7 +403,7 @@ let handler ~size ~out ~verbose c name _ r =
     | QCheck.Test.Generating    -> "generating"
     | QCheck.Test.Collecting _  -> "collecting"
     | QCheck.Test.Testing _     -> "   testing"
-    | QCheck.Test.Shrinked (i, _) ->
+    | QCheck.Test.Shrunk (i, _) ->
       Printf.sprintf "shrinking: %4d" i
     | QCheck.Test.Shrinking (i, j, _) ->
       Printf.sprintf "shrinking: %4d.%04d" i j

--- a/src/QCheck_runner.ml
+++ b/src/QCheck_runner.ml
@@ -409,11 +409,13 @@ let step ~size ~out ~verbose c name _ _ r =
   if verbose then
     Printf.fprintf out "\r[ ] %a -- %s%!" (pp_counter ~size) c name
 
-let callback ~size ~out ~verbose c name _ _ =
+let callback ~size ~out ~verbose ~colors c name _ _ =
   let pass = c.failed = 0 && c.errored = 0 in
+  let color = if pass then `Green else `Red in
   if verbose then
-    Printf.fprintf out "\r[%s] %a -- %s\n%!"
-      (if pass then "✓" else "✗") (pp_counter ~size) c name
+    Printf.fprintf out "\r[%a] %a -- %s\n%!"
+      (Color.pp_str_c ~bold:true ~colors color) (if pass then "✓" else "✗")
+      (pp_counter ~size) c name
 
 let print_inst arb x =
   match arb.QCheck.print with
@@ -478,7 +480,7 @@ let run_tests
     } in
     let r = QCheck.Test.check_cell ~long ~rand
         ~step:(step ~size ~out ~verbose c)
-        ~call:(callback ~size ~out ~verbose c)
+        ~call:(callback ~size ~out ~verbose ~colors c)
         cell
     in
     Res (cell, r)


### PR DESCRIPTION
Following comments in issue #33, this pull request make the verbose mode a bit better. The modifications made are:

- Add colors to the checkmarks printed to the left
- Print the status line of a test before it begin (compared to previsouly where it would only be printed after the first instance had been tested)
- Add a notion of event to `QCheck.Test.check_cell`, to represent intermediary events during the testing of an instance
- Use the event handler to print the current status of a test (either generating a an instance, collecting statistics about that instance, testing the law on the instance, or shrinking an instance)

For people interested in seeing the new features in action, I found that using the seed `80394201` makes the `fold_left fold_right uncurried` test take about 3s on my laptop, which is enough to see the progress. On that same example, I didn't notice any significant slowdown due to the event handler.

The current state of the test instance (generating, collecting, testing or shrinking), is currently printed to the right of the test name in parentheses, because I didn't find any other satisfying solution, if anyone has a better idea, I'm open to suggestions.