### PR TITLE
Allow setting time_between_msg in runner

### DIFF
--- a/src/QCheck_runner.ml
+++ b/src/QCheck_runner.ml
@@ -347,7 +347,11 @@ let default_rand () =
 (* time of last printed message. Useful for rate limiting in verbose mode *)
 let last_msg = ref 0.
 
-let time_between_msg = 0.1
+let time_between_msg = ref 0.1
+
+let get_time_between_msg () = !time_between_msg
+
+let set_time_between_msg f = time_between_msg := f
 
 let to_ounit2_test ?(rand = default_rand()) (QCheck.Test.Test cell) =
   let module T = QCheck.Test in
@@ -405,7 +409,7 @@ let handler ~size ~out ~verbose c name _ r =
   in
   (* use timestamps for rate-limiting *)
   let now=Unix.gettimeofday() in
-  if verbose && now -. !last_msg > time_between_msg then (
+  if verbose && now -. !last_msg > get_time_between_msg () then (
     last_msg := now;
     Printf.fprintf out "%s[ ] %a %s (%s)%!"
       Color.reset_line (pp_counter ~size) c name (st r)
@@ -422,7 +426,7 @@ let step ~size ~out ~verbose c name _ _ r =
   c.gen <- c.gen + 1;
   aux r;
   let now=Unix.gettimeofday() in
-  if verbose && now -. !last_msg > time_between_msg then (
+  if verbose && now -. !last_msg > get_time_between_msg () then (
     last_msg := now;
     Printf.fprintf out "%s[ ] %a %s%!"
       Color.reset_line (pp_counter ~size) c name

--- a/src/QCheck_runner.mli
+++ b/src/QCheck_runner.mli
@@ -50,6 +50,12 @@ val set_verbose : bool -> unit
 val set_long_tests : bool -> unit
 (** Change the value of [long_tests ()] *)
 
+val get_time_between_msg : unit -> float
+(** Get the minimum time to wait between printing messages. *)
+
+val set_time_between_msg : float -> unit
+(** Set the minimum tiem between messages. *)
+
 (** {2 Conversion of tests to OUnit Tests} *)
 
 val to_ounit_test :


### PR DESCRIPTION
In my tests, the `time_between_msg` float ref has resulted in only the `(collecting)` messages being printed and never others such as `generating`.

More generally, a non-zero value will always prevent the first `(generating)` message from being printed since the `step` printing function should not really take a lot of time. Also, assuming generation is reasonably fast but testing takes some time (which is the typical case I assume), `(collecting)` has an overwhelming chance of being the one and only phase being printed, since it is the first phase after testing: indeed, assume the step function (or the last `collection`) has been printed at time `t`, then assuming the printing is fast (or there is nothing to collect), then the generation message will be prevented since it occurs at `t + \epsilon`, afterwards, the testing message happens at `t + \epsilon + generation_time`, and if `generation_time < time_between_msg`(which is likely), then the `testing` message will also be prevented. However, if the testing takes some time (i.e more than `time_between_msg`), then `collecting` will be printed again, and so on...

All in all it seems to me that the mechanism is useful to prevent too many messages being printed, but not really optimal, so I think it would make sense to at least let the user decide what value to choose.

A remaining questions would it make sense to add a command-line option to specify the value ?