### PR TITLE
sequence_list : a t list -> a list t

### DIFF
--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -318,6 +318,13 @@ module Iter = struct
   let quad a b c d yield =
     a (fun x -> b (fun y -> c (fun z -> d (fun w -> yield (x,y,z,w)))))
 
+  let sequence_list (type a) (gs  : a t list) : a list t = fun yield ->
+    List.fold_left (fun acc g yield ->
+        acc @@ fun rev_xs ->
+        g @@ fun x ->
+        yield (x :: rev_xs)
+    ) (return []) gs @@ fun rev_xs -> yield (List.rev rev_xs)
+
   exception IterExit
   let find_map p iter =
     let r = ref None in

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -412,11 +412,13 @@ module Iter : sig
 
   val of_list : 'a list -> 'a t
   val of_array : 'a array -> 'a t
+
   val pair : 'a t -> 'b t -> ('a * 'b) t
   val triple : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
   val quad : 'a t -> 'b t -> 'c t -> 'd t -> ('a * 'b * 'c * 'd) t
-  val find : ('a -> bool) -> 'a t -> 'a option
+  val sequence_list : 'a t list -> 'a list t
 
+  val find : ('a -> bool) -> 'a t -> 'a option
   val filter : ('a -> bool) -> 'a t -> 'a t
 
   val append_l : 'a t list -> 'a t


### PR DESCRIPTION
I need to recursively shrink a list of values (I want to enumerate
lists of all shrunk values) and I don't see how to do it without this
function.

Haskell typically exposes both (List specializing the traversable
datatype here)

    sequence : Applicative f => f (List a) -> f (List a)
    traverse : Applicative f => (a -> f b) -> List a -> f (List b)

For now I propose only `sequence` to keep the API simpler, and also
because it is a natural (homogeneous) extension of pair, triple, quad.
