### PR TITLE
Shrink: decompose Shrink.list into Shrink.list_spine and Shrink.list_elems

### DIFF
--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -467,6 +467,12 @@ module Shrink : sig
       the elements of the list themselves (e.g. in an [int list]
       one can try to decrease the integers). *)
 
+  val list_spine : 'a list t
+  (** Try to shrink lists by removing one or more elements. *)
+
+  val list_elems : 'a t -> 'a list t
+  (** Shrinks the elements of a list, without changing the list size. *)
+
   val array : ?shrink:'a t -> 'a array t
   (** Shrink an array.
       @param shrink see {!list} *)


### PR DESCRIPTION
See the discussion in #68 -- I think that this PR should supersed #68.


> I'm not sure what is best, but my conclusion for now is that a generic `Iter` combinator (at this level I think my implementation is the right/canonical one) has a behavior that is not optimal for the use-case (shrinking a list of values), so this PR is maybe not the best idea. We should rather provide a function in the `Shrink` module, that does something better than the current `Shrink.list`.
>
> Ideally we would have `Shrink.list_spine : 'a list t` and `Shrink.list_elems : 'a t -> 'a list t`, the first one only drops elements of the input and the second only shrinks elements of the input, and then `Shrink.list` is just `compose Shrink.list_spine (Shrink.list_elems ~shrink)`.

I was a bit surprised to find out that `Shrink.list` is not dropping elements then shrinking the remaining elements recursively, but it is returning `Shrink.list_spine l <+> Shrink.list_elems shrink l`, concatenating the transformations instead of composing them. I did not change the implementation.