### PR TITLE
Add float generators with bound and range

### DIFF
--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -130,6 +130,12 @@ module Gen = struct
     | b_pos when bound > 0. -> RS.float st (b_pos -. epsilon_float)
     | b_neg -> RS.float st (b_neg +. epsilon_float)
 
+  let float_range low high =
+    if high < low || high -. low > max_float then invalid_arg "Gen.float_range";
+    fun st -> low +. (float_bound_inclusive (high -. low) st)
+
+  let (--.) = float_range
+
   let neg_int st = -(nat st)
 
   let opt f st =
@@ -627,6 +633,8 @@ let float_bound_inclusive bound =
 
 let float_bound_exclusive bound =
   make_scalar ~print:string_of_float (Gen.float_bound_exclusive bound)
+
+let float_range low high = make_scalar ~print:string_of_float (Gen.float_range low high)
 
 let int = make_int Gen.int
 let int_bound n = make_int (Gen.int_bound n)

--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -122,6 +122,14 @@ module Gen = struct
   let pfloat st = abs_float (float st)
   let nfloat st = -.(pfloat st)
 
+  let float_bound_inclusive bound st = RS.float st bound
+
+  let float_bound_exclusive bound st =
+    match bound with
+    | 0. -> raise (Invalid_argument "Gen.float_bound_exclusive")
+    | b_pos when bound > 0. -> RS.float st (b_pos -. epsilon_float)
+    | b_neg -> RS.float st (b_neg +. epsilon_float)
+
   let neg_int st = -(nat st)
 
   let opt f st =
@@ -613,6 +621,12 @@ let bool = make_scalar ~print:string_of_bool Gen.bool
 let float = make_scalar ~print:string_of_float Gen.float
 let pos_float = make_scalar ~print:string_of_float Gen.pfloat
 let neg_float = make_scalar ~print:string_of_float Gen.nfloat
+
+let float_bound_inclusive bound =
+  make_scalar ~print:string_of_float (Gen.float_bound_inclusive bound)
+
+let float_bound_exclusive bound =
+  make_scalar ~print:string_of_float (Gen.float_bound_exclusive bound)
 
 let int = make_int Gen.int
 let int_bound n = make_int (Gen.int_bound n)

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -190,11 +190,11 @@ module Gen : sig
   val shuffle_l : 'a list -> 'a list t
   (** Creates a generator of shuffled lists. *)
 
-  val unit: unit t (** The unit generator. *)
+  val unit : unit t (** The unit generator. *)
 
-  val bool: bool t (** The boolean generator. *)
+  val bool : bool t (** The boolean generator. *)
 
-  val float: float t   (** Generates floating point numbers. *)
+  val float : float t   (** Generates floating point numbers. *)
 
   val pfloat : float t (** Generates positive floating point numbers (0. included). *)
 

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -202,20 +202,24 @@ module Gen : sig
 
   val float_bound_inclusive : float -> float t
   (** [float_bound_inclusive bound] returns a random floating-point number between 0 and
-  [bound] (inclusive).  If [bound] is negative, the result is negative or zero.  If
-  [bound] is 0, the result is 0. *)
+      [bound] (inclusive).  If [bound] is negative, the result is negative or zero.  If
+      [bound] is 0, the result is 0.
+      @since NEXT_RELEASE *)
 
   val float_bound_exclusive : float -> float t
   (** [float_bound_exclusive bound] returns a random floating-point number between 0 and
-  [bound] (exclusive).  If [bound] is negative, the result is negative or zero.
-  @raise Invalid_argument if [bound] is zero. *)
+      [bound] (exclusive).  If [bound] is negative, the result is negative or zero.
+      @raise Invalid_argument if [bound] is zero.
+      @since NEXT_RELEASE *)
 
   val float_range : float -> float -> float t
   (** [float_range low high] generates floating-point numbers within [low] and [high] (inclusive)
-      @raise Invalid_argument if [high < low] or if the range is larger than [max_float]. *)
+      @raise Invalid_argument if [high < low] or if the range is larger than [max_float].
+      @since NEXT_RELEASE *)
 
   val (--.) : float -> float -> float t
-  (** Synonym for [float_range]  *)
+  (** Synonym for [float_range]
+      @since NEXT_RELEASE *)
 
   val nat : int t (** Generates small natural numbers. *)
 
@@ -911,16 +915,19 @@ val neg_float : float arbitrary
 
 val float_bound_inclusive : float -> float arbitrary
 (** [float_bound_inclusive n] is uniform between [0] and [n] included. If [bound] is
-    negative, the result is negative or zero.  If [bound] is 0, the result is 0. *)
+    negative, the result is negative or zero.  If [bound] is 0, the result is 0.
+    @since NEXT_RELEASE *)
 
 val float_bound_exclusive : float -> float arbitrary
 (** [float_bound_exclusive n] is uniform between [0] included and [n] excluded.
     If [bound] is negative, the result is negative or zero.
-    @raise Invalid_argument if [bound] is zero. *)
+    @raise Invalid_argument if [bound] is zero.
+    @since NEXT_RELEASE *)
 
 val float_range : float -> float -> float arbitrary
 (** [float_range low high] is uniform between [low] included and [high] included.
-    @raise Invalid_argument if [low > high] or if the range is larger than [max_float]. *)
+    @raise Invalid_argument if [low > high] or if the range is larger than [max_float].
+    @since NEXT_RELEASE *)
 
 val int : int arbitrary
 (** Int generator. Uniformly distributed. *)

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -200,6 +200,16 @@ module Gen : sig
 
   val nfloat : float t (** Generates negative floating point numbers. (-0. included) *)
 
+  val float_bound_inclusive : float -> float t
+  (** [float_bound_inclusive bound] returns a random floating-point number between 0 and
+  [bound] (inclusive).  If [bound] is negative, the result is negative or zero.  If
+  [bound] is 0, the result is 0. *)
+
+  val float_bound_exclusive : float -> float t
+  (** [float_bound_exclusive bound] returns a random floating-point number between 0 and
+  [bound] (exclusive).  If [bound] is negative, the result is negative or zero.
+  @raise Invalid_argument if [bound] is zero. *)
+
   val nat : int t (** Generates small natural numbers. *)
 
   val big_nat : int t (** Generates natural numbers, possibly large. @since 0.10 *)
@@ -891,6 +901,15 @@ val pos_float : float arbitrary
 
 val neg_float : float arbitrary
 (** Negative float generator (no nan and no infinities). *)
+
+val float_bound_inclusive : float -> float arbitrary
+(** [float_bound_inclusive n] is uniform between [0] and [n] included. If [bound] is
+    negative, the result is negative or zero.  If [bound] is 0, the result is 0. *)
+
+val float_bound_exclusive : float -> float arbitrary
+(** [float_bound_exclusive n] is uniform between [0] included and [n] excluded.
+    If [bound] is negative, the result is negative or zero.
+    @raise Invalid_argument if [bound] is zero. *)
 
 val int : int arbitrary
 (** Int generator. Uniformly distributed. *)

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -210,6 +210,13 @@ module Gen : sig
   [bound] (exclusive).  If [bound] is negative, the result is negative or zero.
   @raise Invalid_argument if [bound] is zero. *)
 
+  val float_range : float -> float -> float t
+  (** [float_range low high] generates floating-point numbers within [low] and [high] (inclusive)
+      @raise Invalid_argument if [high < low] or if the range is larger than [max_float]. *)
+
+  val (--.) : float -> float -> float t
+  (** Synonym for [float_range]  *)
+
   val nat : int t (** Generates small natural numbers. *)
 
   val big_nat : int t (** Generates natural numbers, possibly large. @since 0.10 *)
@@ -910,6 +917,10 @@ val float_bound_exclusive : float -> float arbitrary
 (** [float_bound_exclusive n] is uniform between [0] included and [n] excluded.
     If [bound] is negative, the result is negative or zero.
     @raise Invalid_argument if [bound] is zero. *)
+
+val float_range : float -> float -> float arbitrary
+(** [float_range low high] is uniform between [low] included and [high] included.
+    @raise Invalid_argument if [low > high] or if the range is larger than [max_float]. *)
 
 val int : int arbitrary
 (** Int generator. Uniformly distributed. *)


### PR DESCRIPTION
- add `float_bound_inclusive`, `float_bound_exclusive` generators to generate floats between 0 and given bound (proposed by @gasche)

- add `float_range` to generate floats in the given range (solves #58)

- fix minor indentation inconsistency

Note: QCheck has own float generation algorithm, while I used `Random.State.float` for simplicity.