### PR TITLE
Change implementation of 'int_bound'

### DIFF
--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -156,9 +156,9 @@ module Gen = struct
   let int st = if RS.bool st then - (pint st) - 1 else pint st
   let int_bound n =
     if n < 0 then invalid_arg "Gen.int_bound";
-    fun st ->
-      let r = pint st in
-      r mod (n+1)
+    if n <= (1 lsl 30) - 1
+    then fun st -> Random.State.int st n
+    else fun st -> let r = pint st in r mod (n + 1)
   let int_range a b =
     if b < a then invalid_arg "Gen.int_range";
     fun st -> a + (int_bound (b-a) st)

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -243,6 +243,7 @@ module Gen : sig
 
   val int_bound : int -> int t
   (** Uniform integer generator producing integers within [0... bound].
+      For [bound < 2^{30}] is same as [Random.State.int bound].
       @raise Invalid_argument if the argument is negative. *)
 
   val int_range : int -> int -> int t


### PR DESCRIPTION
Together with @gasche, we were implementing our own `Gen.frequency` looking at the implementation by QCheck. 

We saw that to generate a bounded int, it uses `Random.State.int` instead of `int_bound`. As we wanted to have the same values generated by both `Gen.frequency` and our implementation, we also opted for using `Random.State.int`; however, it would be better if we used the API provided by QCheck instead of a lower-level library fn. 

After this change, `int_bound` and `Random.State.int` will generate same values for `bound < 2^{30}` with own implementation for larger values, which would satisfy most of the users, assumably. 

(@gasche can probably phrase it more convincingly if necessary)