### PR TITLE
add weighted shuffled lists generator

### DIFF
--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -209,6 +209,14 @@ module Gen = struct
     shuffle_a a st;
     Array.to_list a
 
+  let shuffle_w_l l st =
+    let sample (w, v) =
+      let fl_w = float_of_int w in
+      (float_bound_inclusive 1. st ** (1. /. fl_w), v)
+    in
+    let samples = List.map sample l in
+    List.sort (fun (w1, _) (w2, _) -> compare w2 w1) samples |> List.map snd
+
   let pair g1 g2 st = (g1 st, g2 st)
 
   let triple g1 g2 g3 st = (g1 st, g2 st, g3 st)

--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -214,8 +214,8 @@ module Gen = struct
       let fl_w = float_of_int w in
       (float_bound_inclusive 1. st ** (1. /. fl_w), v)
     in
-    let samples = List.map sample l in
-    List.sort (fun (w1, _) (w2, _) -> compare w2 w1) samples |> List.map snd
+    let samples = List.rev_map sample l in
+    List.sort (fun (w1, _) (w2, _) -> compare w1 w2) samples |> List.rev_map snd
 
   let pair g1 g2 st = (g1 st, g2 st)
 

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -191,7 +191,18 @@ module Gen : sig
   (** Creates a generator of shuffled lists. *)
 
   val shuffle_w_l : (int * 'a) list -> 'a list t
-  (** Creates a generator of weighted shuffled lists. *)
+  (** Creates a generator of weighted shuffled lists. A given list is shuffled on each
+      generation according to the weights of its elements. An element with a larger weight
+      is more likely to be at the front of the list than an element with a smaller weight.
+      If we want to pick random elements from the (head of) list but need to prioritize
+      some elements over others, this generator can be useful.
+
+      Example: given a weighted list [[1, "one"; 5, "five"; 10, "ten"]], the generator is
+      more likely to generate [["ten"; "five"; "one"]] or [["five"; "ten"; "one"]] than
+      [["one"; "ten"; "five"]] because "ten" and "five" have larger weights than "one".
+
+      @since NEXT_RELEASE
+  *)
 
   val unit : unit t (** The unit generator. *)
 

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -190,6 +190,9 @@ module Gen : sig
   val shuffle_l : 'a list -> 'a list t
   (** Creates a generator of shuffled lists. *)
 
+  val shuffle_w_l : (int * 'a) list -> 'a list t
+  (** Creates a generator of weighted shuffled lists. *)
+
   val unit : unit t (** The unit generator. *)
 
   val bool : bool t (** The boolean generator. *)


### PR DESCRIPTION
Adds a function `shuffle_w_l`, which creates a generator that can shuffle the given list according to the elements' weights. 