### PR TITLE
fix 'int_bound' bound inclusiveness problem

### DIFF
--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -156,8 +156,8 @@ module Gen = struct
   let int st = if RS.bool st then - (pint st) - 1 else pint st
   let int_bound n =
     if n < 0 then invalid_arg "Gen.int_bound";
-    if n <= (1 lsl 30) - 1
-    then fun st -> Random.State.int st n
+    if n <= (1 lsl 30) - 2
+    then fun st -> Random.State.int st (n + 1)
     else fun st -> let r = pint st in r mod (n + 1)
   let int_range a b =
     if b < a then invalid_arg "Gen.int_range";

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -257,7 +257,7 @@ module Gen : sig
 
   val int_bound : int -> int t
   (** Uniform integer generator producing integers within [0... bound].
-      For [bound < 2^{30}] is same as [Random.State.int bound].
+      For [bound < 2^{30} - 1] uses [Random.State.int] for integer generation.
       @raise Invalid_argument if the argument is negative. *)
 
   val int_range : int -> int -> int t


### PR DESCRIPTION
When I changed `int_bound` to use `Random.State.int` (`RS.int`), I did not take into consideration that `int_bound` generates values including `bound`, while `RS.int` doesn't. 

This PR fixes that omission. (It also changes the max bound for using `RS.int` from `2^{30}-1` to `2^{30}-2`, so that we can pass `bound+1` to `RS.int` without int representation problems on 32-bit machines.

