### PR TITLE
Fix singleton list shrinking

### DIFF
--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -423,7 +423,7 @@ module Shrink = struct
 
   let list_spine l yield =
     let n = List.length l in
-    let chunk_size = ref (n/2) in
+    let chunk_size = ref ((n+1)/2) in
 
     (* push the [n] first elements of [l] into [q], return the rest of the list *)
     let rec fill_queue n l q = match n,l with


### PR DESCRIPTION
I just got bitten by a little embarrasing issue:
The reworked list shrinker fails to shrink a one-element list! 😮
```
utop # Shrink.list [0] (fun is -> Printf.printf "%s\n" (Print.list Print.int is));;
- : unit = ()
```

The problem is the `chunk_size` computed as `n/2` which is `0` over `int` when `n` is `1`.
Simply adding one before halving fixes it, and will generally increment the `chunk_size` for any odd-length counterexample. For example, here are the shrinking steps of a 35-element list:
```ocaml
utop # Random.init 123456;;
- : unit = ()
─( 14:35:49 )─< command 24 >─────────────────────────────────────────────────────────────────────────────────────────{ counter: 0 }─
utop # let print_list xs = print_endline (Print.list Print.int xs) in
  Test.check_exn ~rand:(Random.get_state ()) (Test.make (list small_int) (fun xs -> print_list xs; xs = []));;
[3; 4; 0; 0; 0; 0; 90; 1; 8; 4; 5; 5; 8; 0; 6; 5; 7; 3; 11; 1; 2; 4; 2; 1; 1; 4; 0; 9; 9; 2; 48; 6; 2; 48; 7]
[11; 1; 2; 4; 2; 1; 1; 4; 0; 9; 9; 2; 48; 6; 2; 48; 7]
[9; 9; 2; 48; 6; 2; 48; 7]
[6; 2; 48; 7]
[48; 7]
[7]
[]
[4]
[]
[2]
[]
[1]
[]
[0]
[]
Exception:
QCheck.Test.Test_fail ("anon_test_10", ["[0] (after 9 shrink steps)"]).
``` 