### PR TITLE
Int shrinkers

### DIFF
--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -383,6 +383,24 @@ module Shrink = struct
     if x<0 then yield (x+1);
     ()
 
+  let int32 x yield =
+    let open Int32 in
+    let y = ref x in
+    (* try some divisors *)
+    while !y < -2l || !y > 2l do y := div !y 2l; yield (sub x !y); done; (* fast path *)
+    if x>0l then yield (pred x);
+    if x<0l then yield (succ x);
+    ()
+
+  let int64 x yield =
+    let open Int64 in
+    let y = ref x in
+    (* try some divisors *)
+    while !y < -2L || !y > 2L do y := div !y 2L; yield (sub x !y); done; (* fast path *)
+    if x>0L then yield (pred x);
+    if x<0L then yield (succ x);
+    ()
+
   (* aggressive shrinker for integers,
      get from 0 to x, by dichotomy or just enumerating smaller values *)
   let int_aggressive x yield =

--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -689,8 +689,12 @@ let small_signed_int = make_int Gen.small_signed_int
 let small_int_corners () = make_int (Gen.nng_corners ())
 let neg_int = make_int Gen.neg_int
 
-let int32 = make_scalar ~print:(fun i -> Int32.to_string i ^ "l") Gen.ui32
-let int64 = make_scalar ~print:(fun i -> Int64.to_string i ^ "L") Gen.ui64
+let int32 =
+  make ~print:(fun i -> Int32.to_string i ^ "l") ~small:small1
+    ~shrink:Shrink.int32 Gen.ui32
+let int64 =
+  make ~print:(fun i -> Int64.to_string i ^ "L") ~small:small1
+    ~shrink:Shrink.int64 Gen.ui64
 
 let char = make_scalar ~print:(sprintf "%C") Gen.char
 let printable_char = make_scalar ~print:(sprintf "%C") Gen.printable

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -516,6 +516,8 @@ module Shrink : sig
   val char : char t (** @since 0.6 *)
 
   val int : int t
+  val int32 : int32 t
+  val int64 : int64 t
 
   val option : 'a t -> 'a option t
 


### PR DESCRIPTION
This is addressing #82.
It just copies the `int` shrinking strategy. Potentially we could factor out the general strategy and parameterize all three integer shrinkers over this common core. For now I chose to keep them very similar and right next to each other.

It seems to work fine:
```
# let t = Test.make int32 (fun i -> i < 2343544l);;
val t : Test.t = QCheck.Test.Test <abstr>
# QCheck_runner.run_tests ~verbose:true [t];;
generated error fail pass / total     time test name
[✗]    1    0    1    0 /  100     0.0s anon_test_3

--- Failure --------------------------------------------------------------------

Test anon_test_3 failed (14 shrink steps):

2343544l
================================================================================
failure (1 tests failed, 0 tests errored, ran 1 tests)
- : int = 1
# QCheck_runner.run_tests ~verbose:true [t];;
generated error fail pass / total     time test name
[✗]    1    0    1    0 /  100     0.0s anon_test_3

--- Failure --------------------------------------------------------------------

Test anon_test_3 failed (16 shrink steps):

2343544l
================================================================================
failure (1 tests failed, 0 tests errored, ran 1 tests)
- : int = 1
# let t = Test.make int64 (fun i -> i < 2343544L);;
val t : Test.t = QCheck.Test.Test <abstr>
# QCheck_runner.run_tests ~verbose:true [t];;
generated error fail pass / total     time test name
[✗]    5    0    1    4 /  100     0.0s anon_test_4

--- Failure --------------------------------------------------------------------

Test anon_test_4 failed (51 shrink steps):

2343544L
================================================================================
failure (1 tests failed, 0 tests errored, ran 1 tests)
- : int = 1
# QCheck_runner.run_tests ~verbose:true [t];;
generated error fail pass / total     time test name
[✗]    1    0    1    0 /  100     0.0s anon_test_4

--- Failure --------------------------------------------------------------------

Test anon_test_4 failed (49 shrink steps):

2343544L
================================================================================
failure (1 tests failed, 0 tests errored, ran 1 tests)
- : int = 1
```

