### PR TITLE
less newline-verbose stats

### DIFF
--- a/src/runner/QCheck_base_runner.ml
+++ b/src/runner/QCheck_base_runner.ml
@@ -346,12 +346,14 @@ let print_success ~colors out cell r =
         (Color.pp_str_c ~colors `Yellow) "Warning" (String.make 68 '!')
         (QCheck.Test.get_name cell) msg)
     (QCheck.TestResult.warnings r);
+
+  if QCheck.TestResult.stats r <> []  then
+     Printf.fprintf out
+       "\n+++ %a %s\n%!"
+       (Color.pp_str_c ~colors `Blue) ("Stats for " ^ QCheck.Test.get_name cell)
+       (String.make 56 '+');
   List.iter
-    (fun st ->
-       Printf.fprintf out
-         "\n+++ %a %s\n\nStat for test %s:\n\n%s%!"
-        (Color.pp_str_c ~colors `Blue) "Stat" (String.make 68 '+')
-        (QCheck.Test.get_name cell) (QCheck.Test.print_stat st))
+    (fun st -> Printf.fprintf out "\n%s%!" (QCheck.Test.print_stat st))
     (QCheck.TestResult.stats r);
   ()
 


### PR DESCRIPTION
This addresses #85.
Rather than print a separator and two headers for each stat, this prints one separator per test that names it and then a single header for each stat.

Compare the following output to #85:
```ocaml
# let t gen name = Test.make ~name:name (add_stat ("mod10", fun i -> i mod 10) (add_stat ("size", fun i -> i) gen)) (fun _ -> true);;
val t : int arbitrary -> string -> Test.t = <fun>
# QCheck_runner.run_tests ~verbose:true [t small_int "small_int dist"; t int "int dist"];;
random seed: 466141584
generated error fail pass / total     time test name
[✓]  100    0    0  100 /  100     0.0s small_int dist
[✓]  100    0    0  100 /  100     0.0s int dist

+++ Stats for small_int dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++

stats mod10:
  num: 100, avg: 5.02, stddev: 2.58, median 5, min 0, max 9
   0: ##################                                                5
   1: ######################                                            6
   2: ########################################                         11
   3: #################################                                 9
   4: #########################                                         7
   5: ###################################################              14
   6: #######################################################          15
   7: ###############################################                  13
   8: ############################################                     12
   9: #############################                                     8

stats size:
  num: 100, avg: 15.12, stddev: 23.89, median 6, min 0, max 96
    0..  4: ###############################                                  30
    5..  9: #######################################################          53
   10.. 14:                                                                   0
   15.. 19: #                                                                 1
   20.. 24:                                                                   0
   25.. 29: #                                                                 1
   30.. 34:                                                                   0
   35.. 39:                                                                   0
   40.. 44:                                                                   0
   45.. 49:                                                                   0
   50.. 54: ###                                                               3
   55.. 59: #                                                                 1
   60.. 64: ##                                                                2
   65.. 69: ##                                                                2
   70.. 74: ##                                                                2
   75.. 79: #                                                                 1
   80.. 84: #                                                                 1
   85.. 89: ##                                                                2
   90.. 94:                                                                   0
   95.. 99: #                                                                 1

+++ Stats for int dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++

stats mod10:
  num: 100, avg: -0.89, stddev: 4.97, median -1, min -9, max 9
  -9: ####################                                              4
  -8: ##############################                                    6
  -7: ##############################                                    6
  -6: #########################                                         5
  -5: #############################################                     9
  -4: #########################                                         5
  -3: ####################                                              4
  -2: ###################################                               7
  -1: ###################################                               7
   0: #######################################################          11
   1: #########################                                         5
   2: ####################                                              4
   3: ##############################                                    6
   4: ###############                                                   3
   5: ####################                                              4
   6: ##############################                                    6
   7: #####                                                             1
   8: ####################                                              4
   9: ###############                                                   3

stats size:
  num: 100, avg: -256060799093919200.00, stddev: 2683694235390315520.00, median -677469905614047954, min -4553997318426253888, max 4533050009676391413
  -4553997318426253888..-4099644952021121601: ##########################################                        7
  -4099644952021121600..-3645292585615989313: ##########################################                        7
  -3645292585615989312..-3190940219210857025: ############                                                      2
  -3190940219210857024..-2736587852805724737: ########################                                          4
  -2736587852805724736..-2282235486400592449: ####################################                              6
  -2282235486400592448..-1827883119995460161: ########################                                          4
  -1827883119995460160..-1373530753590327873: #######################################################           9
  -1373530753590327872.. -919178387185195585: ##########################################                        7
   -919178387185195584.. -464826020780063297: ##########################################                        7
   -464826020780063296..  -10473654374931009: ####################################                              6
    -10473654374931008..  443878712030201279: ##################                                                3
    443878712030201280..  898231078435333567: ############                                                      2
    898231078435333568.. 1352583444840465855: ######                                                            1
   1352583444840465856.. 1806935811245598143: ################################################                  8
   1806935811245598144.. 2261288177650730431: ########################                                          4
   2261288177650730432.. 2715640544055862719: ##############################                                    5
   2715640544055862720.. 3169992910460995007: ############                                                      2
   3169992910460995008.. 3624345276866127295: ##################                                                3
   3624345276866127296.. 4078697643271259583: #######################################################           9
   4078697643271259584.. 4533050009676391871: ########################                                          4
================================================================================
success (ran 2 tests)
- : int = 0

```