### PR TITLE
modify int_range to make it accept ranges bigger than max_int.

### DIFF
--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -162,7 +162,17 @@ module Gen = struct
     else fun st -> let r = pint st in r mod (n + 1)
   let int_range a b =
     if b < a then invalid_arg "Gen.int_range";
-    fun st -> a + (int_bound (b-a) st)
+    if a >= 0 || b <= 0 then (* range smaller than max_int *)
+      fun st -> a + (int_bound (b-a) st)
+    else
+      (* range potentially bigger than max_int: we split on 0 and
+         choose the itv wrt to their size ratio *)
+      fun st ->
+      let f_a = float_of_int a in
+      let ratio = (-.f_a) /. (float_of_int b -. f_a) in
+      if Random.float 1. < ratio then - (int_bound a st)
+      else int_bound b st
+
   let (--) = int_range
 
   (* NOTE: we keep this alias to not break code that uses [small_int]

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -266,7 +266,7 @@ module Gen : sig
 
   val int_range : int -> int -> int t
   (** Uniform integer generator producing integers within [low,high].
-      @raise Invalid_argument if [low > high] or if the range is larger than [max_int]. *)
+      @raise Invalid_argument if [low > high]. *)
 
   val graft_corners : 'a t -> 'a list -> unit -> 'a t
   (** [graft_corners gen l ()] makes a new generator that enumerates


### PR DESCRIPTION
### This PR aims at removing the restriction that makes `int_range` fail on ranges bigger than `max_int`.
The new version first checks if the given intertval has a constant sign, in which case its range is smaller than `max_int`.
Otherwise, it splits it to have two constant intervals and then chooses uniforml (i.e. according to their size ratios computed in float) the one in which he branches to `int_bound`