### PR TITLE
`nat_split`, `pos_split`

### DIFF
--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -328,6 +328,36 @@ module Gen = struct
     let rec f' n st = f f' n st in
     f'
 
+  (* nat splitting *)
+
+  let nat_split2 n st =
+    if (n < 2) then invalid_arg "nat_split2";
+    let n1 = int_range 1 (n - 1) st in
+    (n1, n - n1)
+
+  let pos_split2 n st =
+    let n1 = int_range 0 n st in
+    (n1, n - n1)
+
+  let pos_split ~size:k n st =
+    if (k > n) then invalid_arg "nat_split";
+    (* To split n into n{0}+n{1}+..+n{k-1}, we draw distinct "boundaries"
+       b{-1}..b{k-1}, with b{-1}=0 and b{k-1} = n
+       and the k-1 intermediate boundaries b{0}..b{k-2}
+       chosen randomly distinct in [1;n-1].
+
+       Then each n{i} is defined as b{i}-b{i-1}. *)
+    let b = range_subset ~size:(k-1) 1 (n - 1) st in
+    Array.init k (fun i ->
+      if i = 0 then b.(0)
+      else if i = k-1 then n - b.(i-1)
+      else b.(i) - b.(i-1)
+    )
+
+  let nat_split ~size:k n st =
+    pos_split ~size:k (n+k) st
+    |> Array.map (fun v -> v - 1)
+
   let generate ?(rand=Random.State.make_self_init()) ~n g =
     list_repeat n g rand
 

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -208,6 +208,30 @@ module Gen : sig
       @since 0.11
   *)
 
+  val range_subset : size:int -> int -> int -> int array t
+  (** [range_subset ~size:k low high] generates an array of length [k]
+      of sorted distinct integers in the range [low..high] (included).
+
+      Complexity O(k log k), drawing [k] random integers.
+
+      @raise Invalid_argument outside the valid region [0 <= k <= high-low+1].
+
+      @since 0.18
+  *)
+
+  val array_subset : int -> 'a array -> 'a array t
+  (** [array_subset k arr] generates a sub-array of [k] elements
+      at distinct positions in the input array [arr],
+      in the same order.
+
+      Complexity O(k log k), drawing [k] random integers.
+
+      @raise Invalid_argument outside the valid region
+      [0 <= size <= Array.length arr].
+
+      @since 0.18
+  *)
+
   val unit : unit t (** The unit generator. *)
 
   val bool : bool t (** The boolean generator. *)

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -446,6 +446,51 @@ module Gen : sig
 
   *)
 
+  val nat_split2 : int -> (int * int) t
+  (** [nat_split2 n] generates pairs [(n1, n2)] of natural numbers
+      with [n1 + n2 = n].
+
+      This is useful to split sizes to combine sized generators.
+
+      @raise Invalid_argument unless [n >= 2].
+
+      @since 0.18
+  *)
+
+  val pos_split2 : int -> (int * int) t
+  (** [nat_split2 n] generates pairs [(n1, n2)] of strictly positive
+      (nonzero) natural numbers with [n1 + n2 = n].
+
+      This is useful to split sizes to combine sized generators.
+
+      @since 0.18
+  *)
+
+  val nat_split : size:int -> int -> int array t
+  (** [nat_split2 ~size:k n] generates [k]-sized arrays [n1,n2,..nk]
+      of natural numbers in [[0;n]] with [n1 + n2 + ... + nk = n].
+
+      This is useful to split sizes to combine sized generators.
+
+      Complexity O(k log k).
+
+      @since 0.18
+  *)
+
+  val pos_split : size:int -> int -> int array t
+  (** [nat_split2 ~size:k n] generates [k]-sized arrays [n1,n2,..nk]
+      of strictly positive (non-zero) natural numbers with
+      [n1 + n2 + ... + nk = n].
+
+      This is useful to split sizes to combine sized generators.
+
+      Complexity O(k log k).
+
+      @raise Invalid_argument unless [k <= n].
+
+      @since 0.18
+  *)
+
   val delay : (unit -> 'a t) -> 'a t
   (** Delay execution of some code until the generator is actually called.
       This can be used to manually implement recursion or control flow


### PR DESCRIPTION
The goal of this PR is to implement a function that takes a natural number `n` and parameter `k`, and uniformly splits `n` into `k` numbers `n1..nk` that sum back to `n` (`n1 + ... +nk = n`). This is useful when splitting "fuel" or "size" in a random generator, among `k` components instead of just two. (cc @olivier-martinot, with whom I am collaborating on a random generator that would benefit.)

Two variants are provided: in `nat_split`, the `n1..nk` are natural numbers (range `[0;n]`), in `pos_split` they are strictly positive (range `[1;n]`, or in fact `[1;n-k]`).

The code for these functions is simple and relies on a generic helper that is also useful. However getting them right is tricky, and random generators are hard to test. I checked the implementation in an experimental version of my [random-generator](https://github.com/gasche/random-generator/) library that computes finite distributions.

```
# open Random_generator.Generator.Make(Random_generator.Prob_monad.Distr);;
# Gen.Nat.split ~size:3 5 |> Gen.run ~cmp:Stdlib.compare;;
- : ((int * int) * int list) list =
[((1, 21), [0; 0; 5]); ((1, 21), [0; 1; 4]); ((1, 21), [0; 2; 3]);
 ((1, 21), [0; 3; 2]); ((1, 21), [0; 4; 1]); ((1, 21), [0; 5; 0]);
 ((1, 21), [1; 0; 4]); ((1, 21), [1; 1; 3]); ((1, 21), [1; 2; 2]);
 ((1, 21), [1; 3; 1]); ((1, 21), [1; 4; 0]); ((1, 21), [2; 0; 3]);
 ((1, 21), [2; 1; 2]); ((1, 21), [2; 2; 1]); ((1, 21), [2; 3; 0]);
 ((1, 21), [3; 0; 2]); ((1, 21), [3; 1; 1]); ((1, 21), [3; 2; 0]);
 ((1, 21), [4; 0; 1]); ((1, 21), [4; 1; 0]); ((1, 21), [5; 0; 0])]

utop # Gen.Nat.pos_split ~size:3 5 |> Gen.run ~cmp:Stdlib.compare;;
- : ((int * int) * int list) list =
[((1, 6), [1; 1; 3]); ((1, 6), [1; 2; 2]); ((1, 6), [1; 3; 1]);
 ((1, 6), [2; 1; 2]); ((1, 6), [2; 2; 1]); ((1, 6), [3; 1; 1])]
```

Apparently there are `21` different ways to split `5` into three natural numbers, and `6` ways to split it into three strictly-positive numbers. (The pair `(a, b)` before an output represents the rational number `a/b`, the probability of observing this output.)