### PR TITLE
Remove arbitrary from QCheck2

### DIFF
--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -1,6 +1,7 @@
 (*
 QCheck: Random testing for OCaml
-copyright (c) 2013-2017, Guillaume Bury, Simon Cruanes, Vincent Hugot, Jan Midtgaard
+copyright (c) 2013-2017, Guillaume Bury, Simon Cruanes, Vincent Hugot,
+Jan Midtgaard, Julien Debon, Valentin Chaboche
 all rights reserved.
 *)
 

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -1231,7 +1231,7 @@ module Test = struct
     law : 'a -> bool; (* the law to check *)
     gen : 'a Gen.t; (* how to generate/shrink instances *)
     print : 'a Print.t option; (* how to print values *)
-    collect : ('a -> string) option; (* /!\ TODO: collect ? *)
+    collect : ('a -> string) option; (* collect values by tag, useful to display distribution of generated *)
     stats : 'a stat list; (* distribution of values of type 'a *)
     qcheck1_shrink : ('a -> ('a -> unit) -> unit) option; (* QCheck1-backward-compatible shrinking *)
     if_assumptions_fail: [`Fatal | `Warning] * float;
@@ -1290,9 +1290,7 @@ module Test = struct
       ?(count=default_count) ?(long_factor=1) ?max_gen
       ?(max_fail=1) ?(name=fresh_name()) ~gen ?shrink ?print ?collect ~stats law
     =
-    (* Make a "fake" QCheck2 arbitrary with no shrinking
-       /!\ TODO: can't it be translate to a QCheck2.gen to have an automatic shrinking ?
-     *)
+    (* Make a "fake" QCheck2 arbitrary with no shrinking *)
     let fake_gen = Gen.make_primitive ~gen ~shrink:(fun _ -> Seq.empty) in
     let max_gen = match max_gen with None -> count + 200 | Some x->x in
     {

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -683,7 +683,7 @@ module Gen = struct
 
   let int_corners = int_pos_corners @ [min_int]
 
-  let nng_corners () : int t = graft_corners nat int_pos_corners ()
+  let small_int_corners () : int t = graft_corners nat int_pos_corners ()
 
   (* sized, fix *)
 

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -518,16 +518,14 @@ module Gen = struct
     let shrink a = fun () -> Shrink.int32_towards 0l a () in
     Tree.make_primitive shrink x
 
-  (** TODO Not actually unsigned, fix in https://github.com/c-cube/qcheck/issues/105 *)
-  let ui32 : int32 t = int32
+  let ui32 : int32 t = map Int32.abs int32
 
   let int64 : int64 t = fun st ->
     let x = random_binary_string 64 st |> Int64.of_string in
     let shrink a = fun () -> Shrink.int64_towards 0L a () in
     Tree.make_primitive shrink x
 
-  (** TODO Not actually unsigned, fix in https://github.com/c-cube/qcheck/issues/105 *)
-  let ui64 : int64 t = int64
+  let ui64 : int64 t = map Int64.abs int64
 
   let list_size (size : int t) (gen : 'a t) : 'a list t =
     size >>= fun size ->

--- a/src/core/QCheck2.mli
+++ b/src/core/QCheck2.mli
@@ -1278,7 +1278,7 @@ type 'f fun_repr
 *)
 type 'f fun_ = Fun of 'f fun_repr * 'f
 
-val fun1 : 'a Observable.t -> 'b Gen.t -> ('a -> 'b) fun_ Gen.t
+val fun1 : 'a Observable.t -> ?print:('b Print.t) -> 'b Gen.t -> ('a -> 'b) fun_ Gen.t
 (** [fun1 obs gen] generates random functions that take an argument observable
     via [obs] and map to random values generated with [gen].
     To write functions with multiple arguments, it's better to use {!Tuple}
@@ -1289,6 +1289,7 @@ val fun1 : 'a Observable.t -> 'b Gen.t -> ('a -> 'b) fun_ Gen.t
 val fun2 :
   'a Observable.t ->
   'b Observable.t ->
+  ?print:'c Print.t ->
   'c Gen.t ->
   ('a -> 'b -> 'c) fun_ Gen.t
 (** Specialized version of {!fun_nary} for functions of 2 arguments, for convenience.
@@ -1298,6 +1299,7 @@ val fun3 :
   'a Observable.t ->
   'b Observable.t ->
   'c Observable.t ->
+  ?print:'d Print.t ->
   'd Gen.t ->
   ('a -> 'b -> 'c -> 'd) fun_ Gen.t
 (** Specialized version of {!fun_nary} for functions of 3 arguments, for convenience.
@@ -1308,12 +1310,13 @@ val fun4 :
   'b Observable.t ->
   'c Observable.t ->
   'd Observable.t ->
+  ?print:'e Print.t ->
   'e Gen.t ->
   ('a -> 'b -> 'c -> 'd -> 'e) fun_ Gen.t
 (** Specialized version of {!fun_nary} for functions of 4 arguments, for convenience.
     @since 0.6 *)
 
-val fun_nary : 'a Tuple.obs -> 'b Gen.t -> ('a Tuple.t -> 'b) fun_ Gen.t
+val fun_nary : 'a Tuple.obs -> ?print:('b Print.t) -> 'b Gen.t -> ('a Tuple.t -> 'b) fun_ Gen.t
 (** [fun_nary tuple_obs gen] generates random n-ary functions. Arguments are observed
     using [tuple_obs] and return values are generated using [gen].
 

--- a/src/core/QCheck2.mli
+++ b/src/core/QCheck2.mli
@@ -216,6 +216,11 @@ module Gen : sig
 
       @since 0.5.2 *)
 
+  val small_int_corners : unit -> int t
+  (** As {!small_int}, but each newly created generator starts with
+    a list of corner cases before falling back on random generation. *)
+
+
   val int32 : int32 t
   (** Generates uniform {!int32} values.
 

--- a/src/core/QCheck2.mli
+++ b/src/core/QCheck2.mli
@@ -679,8 +679,7 @@ module Gen : sig
   val fix : (('a -> 'b t) -> 'a -> 'b t) -> 'a -> 'b t
   (** Parametrized fixpoint combinator for generating recursive values.
 
-      /!\ TODO: description here.
-      The fixpoint is parametrized over an arbitrary state ['a], and the
+      The fixpoint is parametrized over an generator state ['a], and the
       fixpoint computation may change the value of this state in the recursive
       calls.
 
@@ -1207,72 +1206,6 @@ module Observable : sig
   (** [quad o1 o2 o3 o4] is an observable of quadruples of [('a * 'b * 'c * 'd)]. *)
 end
 
-(** {1 Arbitrary} *)
-
-(*
-  /!\ TODO: take this documentation for Test.cell
-  - [print] generated values to display counter-examples when a test fails
-    - [collect] values by tag, useful to display distribution of generated values
-    - [stats] to get some statistics about generated values
-
-    ⚠️ The collect field is unstable and might be removed, or
-    moved into {!Test}.
-
-    Abstract since QCheck2.
-*)
-
-(* /!\ TODO: move this definition to Test.cell *)
-type 'a stat = string * ('a -> int)
-(** A statistic on a distribution of values of type ['a].
-    The function {b MUST} return a positive integer. *)
-
-(*
-/!\ TODO: all these arbitrary might be missing in Gen
-
-val pos_int : int arbitrary
-(** Positive int generator ([0] included).
-
-    Uniformly distributed.
-
-    Shrinks towards [origin] if specified, otherwise towards [0]. *)
-
-
-val small_int_corners : unit -> int arbitrary
-(** As {!small_int}, but each newly created generator starts with
-    a list of corner cases before falling back on random generation. *)
-
-
-val printable_string : string arbitrary
-(** [printable_string] generates strings with a distribution of length of {!Gen.nat}
-    and distribution of characters of {!Gen.printable}.
-
-    Shrinks on {!Gen.nat} first, then on {!Gen.printable}. *)
-
-val printable_string_of_size : int Gen.t -> string arbitrary
-(** [printable_string_of_size size] generates strings with a distribution of length of [size]
-    and distribution of characters of {!Gen.printable}.
-
-    Shrinks on [size] first, then on {!Gen.printable}. *)
-
-val small_printable_string : string arbitrary
-(** [small_printable_string] generates strings with a distribution of length of {!Gen.small_nat}
-    and distribution of characters of {!Gen.printable}.
-
-    Shrinks on {!Gen.small_nat} first, then on {!Gen.printable}. *)
-
-val numeral_string : string arbitrary
-(** [numeral_string] generates strings with a distribution of length of {!Gen.nat}
-    and distribution of characters of {!Gen.numeral}.
-
-    Shrinks on {!Gen.nat} first, then on {!Gen.numeral}. *)
-
-val numeral_string_of_size : int Gen.t -> string arbitrary
-(** [numeral_string_of_size size] generates strings with a distribution of length of [size]
-    and distribution of characters of {!Gen.numeral}.
-
-    Shrinks on [size] first, then on {!Gen.numeral}. *)
-
-              *)
   
 (** Utils on combining function arguments. *)
 module Tuple : sig
@@ -1473,6 +1406,10 @@ val assume_fail : unit -> 'a
     and use {!QCheck_runner}.
 *)
 
+type 'a stat = string * ('a -> int)
+(** A statistic on a distribution of values of type ['a].
+  The function {b MUST} return a positive integer. *)
+
 (** Result of running a test *)
 module TestResult : sig
   type 'a counter_ex = {
@@ -1519,14 +1456,12 @@ module TestResult : sig
   val get_count_gen : _ t -> int
   (** [get_count_gen t] returns the number of generated cases. *)
 
-  (* /!\ TODO: not sure how to translate this *)
   val get_collect : _ t -> (string,int) Hashtbl.t option
-  (** [get_collect t] returns the repartition of generated arbitrary instances.
+  (** [get_collect t] returns the repartition of generated values.
       @since NEXT_RELEASE *)
 
-  (* /!\ TODO: same here *)
   val get_stats : 'a t -> ('a stat * (int,int) Hashtbl.t) list
-  (** [get_stats t] returns the statistics captured by the arbitrary.
+  (** [get_stats t] returns the statistics captured by the test.
       @since NEXT_RELEASE *)
 
   val get_warnings : _ t -> string list
@@ -1574,8 +1509,6 @@ module Test : sig
   type 'a cell
   (** A single property test on a value of type ['a]. A {!Test.t} wraps a [cell]
       and hides its type parameter. *)
-
-  (* /!\ TODO: move 'a stat here *)
      
   val make_cell :
     ?if_assumptions_fail:([`Fatal | `Warning] * float) ->
@@ -1603,7 +1536,7 @@ module Test : sig
         the flag is [`Warning], the test will be a failure if the flag is [`Fatal].
         (since 0.10)
       @param print used in {!Print} to display generated values failing the [prop]
-      @param collect (* /!\ TODO: here *)
+      @param collect (* collect values by tag, useful to display distribution of generated *)
       @param stats on a distribution of values of type 'a
   *)
 
@@ -1793,9 +1726,8 @@ val find_example_gen :
   'a Gen.t ->
   'a
 (** Toplevel version of {!find_example}.
-    (* TODO: I'm not sure th documentation is up to date *)
-    [find_example_gen ~f arb ~n] is roughly the same as
-    [Gen.generate1 (find_example ~f arb |> gen)].
+    [find_example_gen ~f gen] is roughly the same as
+    [Gen.generate1 @@ find_example ~f gen].
     @param rand the random state to use to generate inputs.
     @raise No_example_found if no example was found within [count] tries.
     @since 0.6 *)


### PR DESCRIPTION
`'a arbitrary` is totally removed.

There is still TODOs inside the code, some can be fixed either by me but I need to fetch some information or
you can suggest the changes (it's mainly documentation).

print, stats and collect are inside `'a cell`:
```ocaml

  type 'a cell = {
    count : int; (* number of tests to do *)
    long_factor : int; (* multiplicative factor for long test count *)
    max_gen : int; (* max number of instances to generate (>= count) *)
    max_fail : int; (* max number of failures *)
    law : 'a -> bool; (* the law to check *)
    gen : 'a Gen.t; (* how to generate/shrink instances *)
    print : 'a Print.t option; (* how to print values *)
    collect : ('a -> string) option; (* /!\ TODO: collect ? *)
    stats : 'a stat list; (* distribution of values of type 'a *)
    qcheck1_shrink : ('a -> ('a -> unit) -> unit) option; (* QCheck1-backward-compatible shrinking *)
    if_assumptions_fail: [`Fatal | `Warning] * float;
    mutable name : string; (* name of the law *)
  }
```
Retro-compatibility with QCheck1 works thanks to @Sir4ur0n work in QCheck1:
```ocaml
  let make_cell ?if_assumptions_fail
      ?count ?long_factor ?max_gen
  ?max_fail ?small:_removed_in_qcheck_2 ?name arb law
  =
  let {gen; shrink; print; collect; stats; _} = arb in
  QCheck2.Test.make_cell_from_QCheck1 ?if_assumptions_fail ?count ?long_factor ?max_gen ?max_fail ?name ~gen ?shrink ?print ?collect ~stats law

  let make ?if_assumptions_fail ?count ?long_factor ?max_gen ?max_fail ?small ?name arb law =
    QCheck2.Test.Test (make_cell ?if_assumptions_fail ?count ?long_factor ?max_gen ?max_fail ?small ?name arb law)
```

The `print` move from `arbitrary` to `cell` has one impact: `Observable`. Currently you can't not provide any printing for
an observable, but I believe it's doable with some workaround the type.

Actions:
- [X] Remove `'a arbitrary` from QCheck2
- [X] Retro-compatibility from QCheck1
- [x] Remove every TODO
- [x] Print observable
- [ ] Tests on retro-compatibility (compare `QCheck2.Test.t` from QCheck1 and QCheck2 

Closes #119