### PR TITLE
Lift 4.09 restriction on expect tests

### DIFF
--- a/example/alcotest/dune
+++ b/example/alcotest/dune
@@ -7,7 +7,7 @@
   (targets output.txt)
   (deps ./QCheck_alcotest_test.exe)
   (package qcheck-alcotest)
-  (enabled_if (and (= %{os_type} "Unix") (< %{ocaml_version} 4.09.0)))
+  (enabled_if (= %{os_type} "Unix"))
   (action
     (with-accepted-exit-codes
       1
@@ -19,5 +19,5 @@
 
 (rule
   (alias runtest)
-  (enabled_if (and (= %{os_type} "Unix") (< %{ocaml_version} 4.09.0)))
+  (enabled_if (= %{os_type} "Unix"))
   (action (diff output.txt.expected output.txt)))

--- a/example/alcotest/run_alcotest.sh
+++ b/example/alcotest/run_alcotest.sh
@@ -9,7 +9,7 @@ CODE=$?
 echo "$OUT" | grep -v 'This run has ID' \
   | grep -v 'Full test results in' \
   | grep -v 'Logs saved to' \
-  | grep -v 'Raised at file' \
-  | grep -v 'Called from file' \
+  | grep -v 'Raised at ' \
+  | grep -v 'Called from ' \
   | sed 's/! in .*s\./!/'
 exit $CODE

--- a/example/dune
+++ b/example/dune
@@ -7,7 +7,7 @@
   (targets output.txt)
   (deps ./QCheck_runner_test.exe)
   (package qcheck)
-  (enabled_if (and (= %{os_type} "Unix") (< %{ocaml_version} 4.09.0)))
+  (enabled_if (= %{os_type} "Unix"))
   (action
     (with-accepted-exit-codes
       1
@@ -17,5 +17,5 @@
 
 (rule
   (alias runtest)
-  (enabled_if (and (= %{os_type} "Unix") (< %{ocaml_version} 4.09.0)))
+  (enabled_if (= %{os_type} "Unix"))
   (action (diff output.txt.expected output.txt)))

--- a/example/ounit/dune
+++ b/example/ounit/dune
@@ -7,7 +7,7 @@
   (targets output.txt)
   (deps ./QCheck_ounit_test.exe)
   (package qcheck)
-  (enabled_if (and (= %{os_type} "Unix") (< %{ocaml_version} 4.09.0)))
+  (enabled_if (= %{os_type} "Unix"))
   (action
     (with-accepted-exit-codes
       1
@@ -17,5 +17,5 @@
 
 (rule
   (alias runtest)
-  (enabled_if (and (= %{os_type} "Unix") (< %{ocaml_version} 4.09.0)))
+  (enabled_if (= %{os_type} "Unix"))
   (action (diff output.txt.expected output.txt)))

--- a/example/ounit/run_ounit.sh
+++ b/example/ounit/run_ounit.sh
@@ -8,7 +8,7 @@ CODE=$?
 # remove non deterministic output
 echo "$OUT" \
   | grep -v 'File .*, line .*' \
-  | grep -v 'Called from file' \
-  | grep -v 'Raised at file' \
+  | grep -v 'Called from ' \
+  | grep -v 'Raised at ' \
   | sed 's/in: .*seconds/in: <nondet> seconds/'
 exit $CODE


### PR DESCRIPTION
This is an attempt to lift the `< 4.09` requirement on @c-cube's expect tests.
It works by just omitting `file` from the `grep`ed error string. It has been verified on 4.11.2 and 4.12 locally,
I've furthermore tested the change by making a dummy modification in the `output.txt,expected`-files and verified that any such difference is caught and reported.

Motivation: I wanted to add some more (negative) expect tests of QCheck2(+1) and test that they run locally with 4.12.