### PR TITLE
Stat overflow

### DIFF
--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -1700,7 +1700,10 @@ module Test = struct
            int_of_float (ceil (Int64.to_float sample_width /. float_of_int stat_max_lines))
       else max_idx-min_idx, 1
     in
-    let hist_size = if min_idx + bucket_size * hist_size <= max_idx then 1+hist_size else hist_size in
+    let hist_size =
+      if Int64.(add (of_int min_idx) (mul (of_int bucket_size) (of_int hist_size))) <= Int64.of_int max_idx
+      then 1+hist_size
+      else hist_size in
     (* accumulate bucket counts *)
     let max_val = ref 0 in (* max value after grouping by buckets *)
     let bucket_count = Array.init hist_size (fun _ -> 0) in

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -1693,15 +1693,16 @@ module Test = struct
              median := i));
     (* group by buckets, if there are too many entries: *)
     (* first compute histogram and bucket size *)
+    let min_idx64, max_idx64 = Int64.(of_int min_idx, of_int max_idx) in
     let hist_size, bucket_size =
-      let sample_width = Int64.(sub (of_int max_idx) (of_int min_idx)) in
+      let sample_width = Int64.sub max_idx64 min_idx64 in
       if sample_width > Int64.of_int stat_max_lines
       then stat_max_lines,
            int_of_float (ceil (Int64.to_float sample_width /. float_of_int stat_max_lines))
       else max_idx-min_idx, 1
     in
     let hist_size =
-      if Int64.(add (of_int min_idx) (mul (of_int bucket_size) (of_int hist_size))) <= Int64.of_int max_idx
+      if Int64.(add min_idx64 (mul (of_int bucket_size) (of_int hist_size))) <= max_idx64
       then 1+hist_size
       else hist_size in
     (* accumulate bucket counts *)
@@ -1709,7 +1710,7 @@ module Test = struct
     let bucket_count = Array.init hist_size (fun _ -> 0) in
     Hashtbl.iter
       (fun j count ->
-         let bucket = Int64.(to_int (div (sub (of_int j) (of_int min_idx)) (of_int bucket_size))) in
+         let bucket = Int64.(to_int (div (sub (of_int j) min_idx64) (of_int bucket_size))) in
          let new_count = bucket_count.(bucket) + count in
          bucket_count.(bucket) <- new_count;
          max_val := max !max_val new_count) tbl;

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -1721,9 +1721,8 @@ module Test = struct
       "  num: %d, avg: %.2f, stddev: %.2f, median %d, min %d, max %d\n"
       !num !avg stddev !median min_idx max_idx;
     let indwidth =
-      max (String.length (Printf.sprintf "%d" min_idx))
-        (max (String.length (Printf.sprintf "%d" max_idx))
-           (String.length (Printf.sprintf "%d" (min_idx + bucket_size * hist_size)))) in
+      let str_width i = String.length (Printf.sprintf "%d" i) in
+      List.map str_width [min_idx; max_idx; min_idx + bucket_size * hist_size] |> List.fold_left max min_int in
     let labwidth = if bucket_size=1 then indwidth else 2+2*indwidth in
     for i = 0 to hist_size - 1 do
       let i' = min_idx + i * bucket_size in

--- a/test/core/dune
+++ b/test/core/dune
@@ -1,3 +1,4 @@
 (test
  (name test)
+ (package qcheck-core)
  (libraries qcheck-core alcotest))


### PR DESCRIPTION
This fixes a rare overflow in the histogram labels (and simplifies a couple of other things).

Before (notice the negative labels on the last bucket):
```ocaml
utop # #require "qcheck";;
utop # open QCheck;;
utop # let t = Test.make ~count:1_000 (add_stat ("dist",fun x -> x) (oneof [small_int_corners ();int])) (fun _ -> true);;
val t : Test.t = QCheck.Test.Test <abstr>
utop # QCheck_runner.run_tests ~verbose:true [t];;
random seed: 153870556
generated error fail pass / total     time test name
[✓] 1000    0    0 1000 / 1000     0.0s anon_test_1

+++ Stats for anon_test_1 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++

stats dist:
  num: 1000, avg: -55083208105414400.00, stddev: 1847115855773139200.00, median 9, min -4590718933436425025, max 4611686018427387903
  -4590718933436425025..-4130598685843234370: ##                                                               26
  -4130598685843234369..-3670478438250043714: #                                                                13
  -3670478438250043713..-3210358190656853058: ###                                                              37
  -3210358190656853057..-2750237943063662402: ###                                                              30
  -2750237943063662401..-2290117695470471746: ##                                                               27
  -2290117695470471745..-1829997447877281090: ##                                                               24
  -1829997447877281089..-1369877200284090434: ##                                                               27
  -1369877200284090433.. -909756952690899778: ##                                                               27
   -909756952690899777.. -449636705097709122: ##                                                               21
   -449636705097709121..   10483542495481534: #######################################################         531
     10483542495481535..  470603790088672190: ##                                                               21
    470603790088672191..  930724037681862846: ##                                                               27
    930724037681862847.. 1390844285275053502: ##                                                               24
   1390844285275053503.. 1850964532868244158: ##                                                               25
   1850964532868244159.. 2311084780461434814: ##                                                               28
   2311084780461434815.. 2771205028054625470: ##                                                               23
   2771205028054625471.. 3231325275647816126: ##                                                               23
   3231325275647816127.. 3691445523241006782: ##                                                               25
   3691445523241006783.. 4151565770834197438: #                                                                17
   4151565770834197439.. 4611686018427387903: ##                                                               24
  -4611686018427387713..-4151565770834197058:                                                                   0
================================================================================
success (ran 1 tests)
- : int = 0
```

After the change it behaves better:

```ocaml
utop # open QCheck;;
utop # QCheck_runner.set_seed 153870556;;
random seed: 153870556
- : unit = ()
utop # let t = Test.make ~count:1_000 (add_stat ("dist",fun x -> x) (oneof [small_int_corners ();int])) (fun _ -> true);;
val t : Test.t = QCheck2.Test.Test <abstr>
utop # QCheck_runner.run_tests ~verbose:true [t];;
generated error fail pass / total     time test name
[✓] 1000    0    0 1000 / 1000     0.0s anon_test_1

+++ Stats for anon_test_1 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++

stats dist:
  num: 1000, avg: -55083208105414400.00, stddev: 1847115855773139200.00, median 9, min -4590718933436425025, max 4611686018427387903
  -4590718933436425025..-4130598685843234370: ##                                                               26
  -4130598685843234369..-3670478438250043714: #                                                                13
  -3670478438250043713..-3210358190656853058: ###                                                              37
  -3210358190656853057..-2750237943063662402: ###                                                              30
  -2750237943063662401..-2290117695470471746: ##                                                               27
  -2290117695470471745..-1829997447877281090: ##                                                               24
  -1829997447877281089..-1369877200284090434: ##                                                               27
  -1369877200284090433.. -909756952690899778: ##                                                               27
   -909756952690899777.. -449636705097709122: ##                                                               21
   -449636705097709121..   10483542495481534: #######################################################         531
     10483542495481535..  470603790088672190: ##                                                               21
    470603790088672191..  930724037681862846: ##                                                               27
    930724037681862847.. 1390844285275053502: ##                                                               24
   1390844285275053503.. 1850964532868244158: ##                                                               25
   1850964532868244159.. 2311084780461434814: ##                                                               28
   2311084780461434815.. 2771205028054625470: ##                                                               23
   2771205028054625471.. 3231325275647816126: ##                                                               23
   3231325275647816127.. 3691445523241006782: ##                                                               25
   3691445523241006783.. 4151565770834197438: #                                                                17
   4151565770834197439.. 4611686018427387903: ##                                                               24
================================================================================
success (ran 1 tests)
- : int = 0
```

I'm still not too happy about the statistics code, but this is at least a step in the right direction.