### PR TITLE
Fix the tests and remove out of place (optional)

### DIFF
--- a/example/alcotest/dune
+++ b/example/alcotest/dune
@@ -6,7 +6,6 @@
 (rule
   (targets output.txt)
   (deps ./QCheck_alcotest_test.exe)
-  (package qcheck-alcotest)
   (enabled_if (= %{os_type} "Unix"))
   (action
     (with-accepted-exit-codes
@@ -19,5 +18,6 @@
 
 (rule
   (alias runtest)
+  (package qcheck-alcotest)
   (enabled_if (= %{os_type} "Unix"))
   (action (diff output.txt.expected output.txt)))

--- a/example/dune
+++ b/example/dune
@@ -6,7 +6,6 @@
 (rule
   (targets output.txt)
   (deps ./QCheck_runner_test.exe)
-  (package qcheck-core)
   (enabled_if (= %{os_type} "Unix"))
   (action
     (with-accepted-exit-codes
@@ -18,4 +17,5 @@
 (rule
   (alias runtest)
   (enabled_if (= %{os_type} "Unix"))
+  (package qcheck)
   (action (diff output.txt.expected output.txt)))

--- a/example/ounit/dune
+++ b/example/ounit/dune
@@ -1,12 +1,11 @@
 
 (executables
   (names QCheck_ounit_test QCheck_test)
-  (libraries qcheck ounit2 qcheck-ounit))
+  (libraries ounit2 qcheck-ounit))
 
 (rule
   (targets output.txt)
   (deps ./QCheck_ounit_test.exe)
-  (package qcheck-ounit)
   (enabled_if (= %{os_type} "Unix"))
   (action
     (with-accepted-exit-codes
@@ -17,5 +16,6 @@
 
 (rule
   (alias runtest)
+  (package qcheck-ounit)
   (enabled_if (= %{os_type} "Unix"))
   (action (diff output.txt.expected output.txt)))

--- a/src/dune
+++ b/src/dune
@@ -3,7 +3,6 @@
   (name qcheck)
   (public_name qcheck)
   (wrapped false)
-  (optional)
   (modules QCheck_runner)
   (synopsis "compatibility library for qcheck")
   (libraries qcheck-core qcheck-core.runner qcheck-ounit))

--- a/src/ounit/dune
+++ b/src/ounit/dune
@@ -2,7 +2,6 @@
 (library
   (name qcheck_ounit)
   (public_name qcheck-ounit)
-  (optional)
   (wrapped false)
   (libraries unix bytes qcheck-core qcheck-core.runner ounit2)
   (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -safe-string)


### PR DESCRIPTION
Fix all instance of `dune runtest -p qcheck*` encountered when testing through opam (see https://github.com/ocaml/opam-repository/pull/19207)