### PR TITLE
Fix `QCheck2.Gen.small_string` impl to match interface and documentation

### DIFF
--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -661,7 +661,7 @@ module Gen = struct
 
   let string_readable = string_size ~gen:char nat
 
-  let small_string ?gen st = string_size ?gen small_nat st
+  let small_string ?(gen = char) st = string_size ~gen small_nat st
 
   let small_list gen = list_size small_nat gen
 


### PR DESCRIPTION
This PR updates the `QCheck2.Gen.small_string` to match the interface and documentation following my finding in #153:
```ocaml
  val small_string : ?gen:char t -> string t
  (** Builds a string generator, length is {!small_nat}.
      Accepts an optional character generator (the default is {!char}).

      Shrinks on the number of characters first, then on the characters.
  *)
```