### PR TITLE
Shrinker performance benchmark

### DIFF
--- a/test/core/dune
+++ b/test/core/dune
@@ -23,3 +23,8 @@
   (modules QCheck_unit_tests QCheck2_unit_tests)
   (package qcheck-core)
   (libraries qcheck-core alcotest))
+
+(executable
+  (name shrink_benchmark)
+  (modules shrink_benchmark)
+  (libraries qcheck-core qcheck-core.runner QCheck_tests QCheck2_tests))

--- a/test/core/shrink_benchmark.ml
+++ b/test/core/shrink_benchmark.ml
@@ -17,6 +17,7 @@ let get_name (Test.Test cell) = Test.get_name cell
 
 (** Runners for single tests, test pairs, and test pair lists *)
 
+(* run a single test with the given seed *)
 let run_timed_test seed cell =
   let open TestResult in
   let rand = Random.State.make [| seed |] in
@@ -34,6 +35,7 @@ let run_timed_test seed cell =
     | Failed {instances} -> "fail",(List.hd instances).shrink_steps, "Failed" (* expected *) in
   (dur,res_str,shr_c,!shr_attempts)
 
+(* run a pair of corresponding tests with the given seed *)
 let run_timed_test_pair seed (Test.Test c1, Test.Test c2) =
   let (dur1,res_str1,shr_c1,shr_att1) = run_timed_test seed c1 in
   let (dur2,res_str2,shr_c2,shr_att2) = run_timed_test seed c2 in
@@ -43,53 +45,58 @@ let run_timed_test_pair seed (Test.Test c1, Test.Test c2) =
 
 let non_repeatable_tests = ["big bound issue59";"ints < 209609"]
 
-let run_timing seeds testpairs =
+(* run a list of corresponding test pairs over the given seed list *)
+(* and print the benchmark result to channel [ch]                  *)
+let run_timing ch seeds testpairs =
+  let fprintf = Printf.fprintf in
   let multiple_runs = List.length seeds > 1 in
   (* print iteration header - name (48 chars) *)
-  Printf.printf "%-48s" "";
-  List.iter (fun seed -> Printf.printf "         iteration seed %-7i       %!" seed) seeds;
-  if multiple_runs then Printf.printf "     total\n%!" else print_newline ();
+  Printf.fprintf ch "%-48s" "";
+  List.iter (fun seed -> fprintf ch "         iteration seed %-7i       %!" seed) seeds;
+  if multiple_runs then fprintf ch "     total\n%!" else print_newline ();
   (* print column header - name + 38 chars per iteration *)
-  Printf.printf "%-48s" "Shrink test name";
+  fprintf ch "%-48s" "Shrink test name";
   List.iter (fun _ ->
-               Printf.printf "  %-6s%-10s %!" "Q1/s" "#succ/#att";
-               Printf.printf "  %-6s%-10s %!" "Q2/s" "#succ/#att") seeds;
-  if multiple_runs then Printf.printf " %6s %6s" "Q1/s" "Q2/s";
-  Printf.printf "\n%!";
+               fprintf ch "  %-6s%-10s %!" "Q1/s" "#succ/#att";
+               fprintf ch "  %-6s%-10s %!" "Q2/s" "#succ/#att") seeds;
+  if multiple_runs then fprintf ch " %6s %6s" "Q1/s" "Q2/s";
+  fprintf ch "\n%!";
   (* print separator *)
-  Printf.printf "%s%!" (String.make 48 '-');
-  List.iter (fun _ -> Printf.printf "%s%!" (String.make 38 '-')) seeds;
-  if multiple_runs then Printf.printf "%s%!" (String.make 16 '-');
-  Printf.printf "\n%!";
+  fprintf ch "%s%!" (String.make 48 '-');
+  List.iter (fun _ -> fprintf ch "%s%!" (String.make 38 '-')) seeds;
+  if multiple_runs then fprintf ch "%s%!" (String.make 16 '-');
+  fprintf ch "\n%!";
   (* print timings for each test_pair and seed *)
   let times =
     List.map
       (fun ((test1,_test2) as test_pair) ->
          let name = get_name test1 in
-         Printf.printf "%-48s%!" name;
+         let max_len = 48 in
+         fprintf ch "%-48s%!" (if String.length name<max_len then name else String.sub name 0 max_len);
          if multiple_runs && List.mem name non_repeatable_tests
          then
            begin
-             Printf.printf " - skipped as generator is stateful, making it non-repeatable\n%!";
+             fprintf ch " - skipped as generator is stateful, making it non-repeatable\n%!";
              (0.0,0.0)
            end
          else
            let times =
              List.map (fun seed ->
                  let _res_str,(dur1,shr_cnt1,shr_att1),(dur2,shr_cnt2,shr_att2) = run_timed_test_pair seed test_pair in
-                 Printf.printf " %6.3f %4i/%-6i%!" dur1 shr_cnt1 shr_att1;
-                 Printf.printf " %6.3f %4i/%-6i%!" dur2 shr_cnt2 shr_att2;
+                 fprintf ch " %6.3f %4i/%-6i%!" dur1 shr_cnt1 shr_att1;
+                 fprintf ch " %6.3f %4i/%-6i%!" dur2 shr_cnt2 shr_att2;
                  (dur1,dur2)
                ) seeds in
            let t1_sum,t2_sum = sum_timing_pairs times in
-           if multiple_runs then Printf.printf " %6.3f %6.3f%!" t1_sum t2_sum;
-           Printf.printf "\n%!";
+           if multiple_runs then fprintf ch " %6.3f %6.3f%!" t1_sum t2_sum;
+           fprintf ch "\n%!";
            (t1_sum,t2_sum))
       testpairs in
   let t1_sum,t2_sum = sum_timing_pairs times in
-  Printf.printf "%s%!" (String.make (48 + 38*List.length seeds) ' ');
-  Printf.printf " %6.3f %6.3f\n%!" t1_sum t2_sum
+  fprintf ch "%s%!" (String.make (48 + 38*List.length seeds) ' ');
+  fprintf ch " %6.3f %6.3f\n%!" t1_sum t2_sum
 
+(* merge two corresponding lists of tests *)
 let rec merge_and_validate xs ys = match xs,ys with
   | [],[] -> []
   | [],_  -> failwith "QCheck2_tests.Shrink has more tests than QCheck_tests.Shrink"
@@ -103,7 +110,13 @@ let seeds = [1234;(*4321;*)8743;(*9876;*)6789;
              (*2143*) (* ouch: seed 2143 causes test "lists equal to duplication" to segfault *)
             ]
 let () =
-  merge_and_validate
-    QCheck_tests.(Shrink.tests@Function.tests)
-    QCheck2_tests.(Shrink.tests@Function.tests)
-  |> run_timing seeds
+  let ch = open_out "shrink_bench.log" in
+  try
+    merge_and_validate
+      QCheck_tests.(Shrink.tests@Function.tests)
+      QCheck2_tests.(Shrink.tests@Function.tests)
+    |> run_timing ch seeds;
+    close_out ch
+  with e ->
+    close_out ch;
+    raise e

--- a/test/core/shrink_benchmark.ml
+++ b/test/core/shrink_benchmark.ml
@@ -1,0 +1,109 @@
+open QCheck2
+
+(** For timing and summing run times *)
+let time f () =
+  let start_time = Sys.time () in
+  let res = f () in
+  let end_time = Sys.time () in
+  (end_time -. start_time,res)
+
+let sum_timing_pairs times =
+  let sum_timings = List.fold_left (+.) 0.0 in
+  let t1,t2 = List.split times in
+  sum_timings t1,sum_timings t2
+
+let get_name (Test.Test cell) = Test.get_name cell
+
+
+(** Runners for single tests, test pairs, and test pair lists *)
+
+let run_timed_test seed cell =
+  let open TestResult in
+  let rand = Random.State.make [| seed |] in
+  (* For total attempts, count occ. of 'Shrinking' in "event protocol":
+     Shrunk 0 - Shrinking 0.1 - Shrinking 0.2 - Shrunk 1 - Shrinking 1.1 - Shrinking 1.2  *)
+  let shr_attempts = ref 0 in
+  let handler _ _ e = match e with
+    | Test.Shrinking (_,_,_) -> incr shr_attempts | _ -> () in
+  let dur,res = time (fun () -> QCheck.Test.check_cell ~rand ~handler cell) () in
+  let name = Test.get_name cell in
+  let res_str,shr_c,_msg = match get_state res with
+    | Success            -> failwith (Printf.sprintf "Test %s returned unexpected Success" name)
+    | Error {exn;_}      -> failwith (Printf.sprintf "Test %s returned unexpected Error %s" name (Printexc.to_string exn))
+    | Failed_other {msg} -> failwith (Printf.sprintf "Test %s returned unexpected Failed_other %s" name msg)
+    | Failed {instances} -> "fail",(List.hd instances).shrink_steps, "Failed" (* expected *) in
+  (dur,res_str,shr_c,!shr_attempts)
+
+let run_timed_test_pair seed (Test.Test c1, Test.Test c2) =
+  let (dur1,res_str1,shr_c1,shr_att1) = run_timed_test seed c1 in
+  let (dur2,res_str2,shr_c2,shr_att2) = run_timed_test seed c2 in
+  if res_str1 <> res_str2
+  then failwith (Printf.sprintf "benchmark %s gave different errors: %s and %s" (Test.get_name c1) res_str1 res_str2)
+  else (res_str1,(dur1,shr_c1,shr_att1),(dur2,shr_c2,shr_att2))
+
+let non_repeatable_tests = ["big bound issue59";"ints < 209609"]
+
+let run_timing seeds testpairs =
+  let multiple_runs = List.length seeds > 1 in
+  (* print iteration header - name (48 chars) *)
+  Printf.printf "%-48s" "";
+  List.iter (fun seed -> Printf.printf "         iteration seed %-7i       %!" seed) seeds;
+  if multiple_runs then Printf.printf "     total\n%!" else print_newline ();
+  (* print column header - name + 38 chars per iteration *)
+  Printf.printf "%-48s" "Shrink test name";
+  List.iter (fun _ ->
+               Printf.printf "  %-6s%-10s %!" "Q1/s" "#succ/#att";
+               Printf.printf "  %-6s%-10s %!" "Q2/s" "#succ/#att") seeds;
+  if multiple_runs then Printf.printf " %6s %6s" "Q1/s" "Q2/s";
+  Printf.printf "\n%!";
+  (* print separator *)
+  Printf.printf "%s%!" (String.make 48 '-');
+  List.iter (fun _ -> Printf.printf "%s%!" (String.make 38 '-')) seeds;
+  if multiple_runs then Printf.printf "%s%!" (String.make 16 '-');
+  Printf.printf "\n%!";
+  (* print timings for each test_pair and seed *)
+  let times =
+    List.map
+      (fun ((test1,_test2) as test_pair) ->
+         let name = get_name test1 in
+         Printf.printf "%-48s%!" name;
+         if multiple_runs && List.mem name non_repeatable_tests
+         then
+           begin
+             Printf.printf " - skipped as generator is stateful, making it non-repeatable\n%!";
+             (0.0,0.0)
+           end
+         else
+           let times =
+             List.map (fun seed ->
+                 let _res_str,(dur1,shr_cnt1,shr_att1),(dur2,shr_cnt2,shr_att2) = run_timed_test_pair seed test_pair in
+                 Printf.printf " %6.3f %4i/%-6i%!" dur1 shr_cnt1 shr_att1;
+                 Printf.printf " %6.3f %4i/%-6i%!" dur2 shr_cnt2 shr_att2;
+                 (dur1,dur2)
+               ) seeds in
+           let t1_sum,t2_sum = sum_timing_pairs times in
+           if multiple_runs then Printf.printf " %6.3f %6.3f%!" t1_sum t2_sum;
+           Printf.printf "\n%!";
+           (t1_sum,t2_sum))
+      testpairs in
+  let t1_sum,t2_sum = sum_timing_pairs times in
+  Printf.printf "%s%!" (String.make (48 + 38*List.length seeds) ' ');
+  Printf.printf " %6.3f %6.3f\n%!" t1_sum t2_sum
+
+let rec merge_and_validate xs ys = match xs,ys with
+  | [],[] -> []
+  | [],_  -> failwith "QCheck2_tests.Shrink has more tests than QCheck_tests.Shrink"
+  | _,[]  -> failwith "QCheck_tests.Shrink has more tests than QCheck2_tests.Shrink"
+  | t1::xs,t2::ys ->
+    if get_name t1 = get_name t2
+    then (t1,t2) :: merge_and_validate xs ys
+    else failwith "QCheck_tests.Shrink and QCheck2_tests.Shrink are not in the same order"
+
+let seeds = [1234;(*4321;*)8743;(*9876;*)6789;
+             (*2143*) (* ouch: seed 2143 causes test "lists equal to duplication" to segfault *)
+            ]
+let () =
+  merge_and_validate
+    QCheck_tests.(Shrink.tests@Function.tests)
+    QCheck2_tests.(Shrink.tests@Function.tests)
+  |> run_timing seeds


### PR DESCRIPTION
This PR adds a shrinker benchmark.
It iterates the (factored) shrinker tests in QCheck_tests.ml and QCheck2_tests.ml in pairs.
For each such pair of tests we measure
- time in seconds, denoted `Q1/s` and `Q2/s`
- the number of succesful shrinks, denoted `#succ`
- the number of shrink attempts, denoted `#att`

This is iterated across several seeds to make sure observations hold across more than one random run.
Finally we add up the timings to spot general trends.


Overall, the benchmark gives a reasonable idea of the state of affairs (see output below):
- the QCheck list shrinker tries *way* too many candidates, often making it unbearably inefficient on large lists, e.g, spending 9.8 secs over 5 milion shrink attempts of which only 1.696 are successful(!)
- the QCheck string shrinker does not perform as well as the QCheck2 shrinker, e.g., spending 1.342 seconds on 4465 shrink-steps when QCheck2 gets away with only 24 in 0.002 secs
- the QCheck2 list shrinker could also use a hand, e.g., spending 17.010 secs (twice of QCheck) on `lists shorter than 4332`
- the function shrinkers in both QCheck and QCheck2 suffer from poor list-shrinking and the involved domain+range shrinkers, e.g., QCheck2 spending 15.278 secs on `fold_left fold_right uncurried` in one iteration, whereas QCheck spends  28.631 secs on only 125 successful shrink attempts out of 27750 on `fold_left test, fun first` in another iteration.

The benchmark starts to drill the framework:
- On one seed I had the segfault reported in #175 
- I've also had to cherry-pick random seeds that don't make the benchmark take hours on my laptop.

I've therefore drafted (QCheck) performance improvements that will make such hacks unnecessary. I'll commit them separately.

```
                                                         iteration seed 1234                   iteration seed 8743                   iteration seed 6789               total
Shrink test name                                  Q1/s  #succ/#att   Q2/s  #succ/#att   Q1/s  #succ/#att   Q2/s  #succ/#att   Q1/s  #succ/#att   Q2/s  #succ/#att    Q1/s   Q2/s
----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
big bound issue59                                - skipped as generator is stateful, making it non-repeatable
long_shrink                                       0.051  149/351     1.700 3039/3099    0.010  148/349     1.064 3068/3127    0.013  146/345     1.172 3063/3124    0.074  3.937
ints arent 0 mod 3                                0.000   84/216     0.000    2/2       0.000   71/204     0.000    1/1       0.000   88/215     0.000   88/305     0.000  0.000
ints are 0                                        0.000   62/63      0.000   61/123     0.000   61/62      0.000   61/122     0.000   62/63      0.000   61/123     0.000  0.000
ints < 209609                                    - skipped as generator is stateful, making it non-repeatable
nat < 5001                                        0.000    6/56      0.000    7/77      0.000    6/47      0.000    7/69      0.000    3/24      0.000    8/85      0.000  0.000
char is never produces 'abcdef'                   0.000    0/0       0.000    1/1       0.000    0/0       0.000    0/0       0.000    0/0       0.000    0/0       0.000  0.000
strings are empty                                 0.000  249/250     0.000    8/16      0.050 4466/4467    0.002   13/26      0.000    0/1       0.000    1/2       0.051  0.002
string never has a \000 char                      0.000   25/40      0.000   22/167     0.159 4466/4519    0.003   56/254     0.000   15/18      0.000   15/48      0.159  0.003
string never has a \255 char                      0.001  249/316     0.001   59/318     0.163 4466/4520    0.005   97/529     0.645 9260/9365    0.003   41/194     0.808  0.009
strings have unique chars                         0.003  248/269     0.000   18/30      1.342 4465/4536    0.002   24/52      0.000   14/34      0.000   15/20      1.345  0.002
pairs have different components                   0.000    0/4       0.000    0/6       0.000    0/4       0.000    0/6       0.000    0/6       0.000    0/10      0.000  0.000
pairs have same components                        0.000  125/126     0.000   63/125     0.000  124/125     0.000   62/123     0.000  119/120     0.000   63/125     0.000  0.000
pairs have a zero component                       0.000  124/188     0.000  122/306     0.000  123/186     0.000  122/306     0.000  118/182     0.000  123/308     0.000  0.000
pairs are (0,0)                                   0.000  125/126     0.000   63/125     0.000  124/125     0.000   62/123     0.000  119/120     0.000   63/125     0.000  0.000
pairs are ordered                                 0.000  827/17626   0.000   94/1217    0.000  690/12946   0.000   85/865     0.000  687/13963   0.000   94/1326    0.001  0.001
pairs are ordered reversely                       0.000  124/125     0.000   62/124     0.000  123/124     0.000   62/124     0.000  122/123     0.000   62/124     0.000  0.000
pairs sum to less than 128                        0.000  116/129     0.000   56/126     0.000  120/146     0.000   59/138     0.000  119/141     0.000   57/130     0.000  0.000
pairs lists rev concat                            0.032  140/332     0.016   83/168     0.017  137/335     0.005   75/152     0.000  130/318     0.000   67/136     0.049  0.021
pairs lists no overlap                            0.001   22/47      0.006   27/60      0.000   17/41      0.008   18/41      0.000    6/20      0.000   11/28      0.001  0.014
triples have pair-wise different components       0.000    7/31      0.000    3/15      0.000    6/6       0.000    3/3       0.000    2/6       0.000    3/3       0.000  0.000
triples have same components                      0.000  188/252     0.000   64/127     0.000  177/240     0.000   64/128     0.000  182/246     0.000   62/122     0.000  0.000
triples are ordered                               0.000  188/252     0.000    3/4       0.000  177/178     0.000    3/4       0.000  187/250     0.003   91/1021    0.000  0.003
triples are ordered reversely                     0.000  188/189     0.000   64/126     0.000  177/240     0.000  124/247     0.000  182/183     0.000   65/127     0.000  0.000
quadruples have pair-wise different components    0.000   23/41      0.000    4/4       0.000   11/11      0.000    4/4       0.000   14/38      0.000    4/11      0.000  0.000
quadruples have same components                   0.000  250/377     0.000  126/313     0.000  237/424     0.000  115/292     0.000  242/425     0.000  123/307     0.000  0.001
quadruples are ordered                            0.000  251/315     0.000    5/6       0.000  239/240     0.000    4/5       0.000  244/308     0.000    5/6       0.000  0.000
quadruples are ordered reversely                  0.000  251/252     0.000   66/128     0.000  239/302     0.000  126/250     0.000  244/245     0.000   66/128     0.000  0.000
bind ordered pairs                                0.000  125/125     0.000    1/1       0.000  124/124     0.000    1/1       0.000  120/120     0.000    1/1       0.000  0.000
bind list_size constant                           0.000   50/358     0.000   12/26      0.000   48/338     0.000   12/25      0.000   48/342     0.000   11/21      0.000  0.001
lists are empty                                   0.000   11/16      0.000    8/16      0.000   19/27      0.004   13/26      0.000    4/9       0.000    1/2       0.000  0.004
lists shorter than 10                             0.000   50/1198    0.000   16/30      0.001   71/1637    0.004   21/42      0.000   36/868     0.000   15/29      0.001  0.004
lists shorter than 432                            9.842 1696/5118102  1.213  412/457     9.516 1612/4863421  1.183  405/450     9.506 1667/5037661  0.188  419/447    28.863  2.585
lists shorter than 4332                           3.785   13/190735  6.262 4022/4087    2.496   11/126052  6.124 4020/4067    2.378    7/126607  4.623 4013/4055    8.659 17.010
lists equal to duplication                        0.215   20/23      0.582    4/7       0.000    7/13      0.000    3/6       0.020   20/25      0.140   17/35      0.235  0.722
lists have unique elems                           0.000    7/17      0.000   11/22      0.003   12/44      0.007   17/30      0.000    6/16      0.000   10/20      0.003  0.007
tree contains only 42                             0.000   10/10      0.000    2/2       0.000   10/10      0.000    2/2       0.000   12/13      0.000    2/2       0.000  0.000
fail_pred_map_commute                             0.002  127/628     0.000   16/59      0.000  112/567     0.000   14/65      0.000  114/665     0.002  117/373     0.002  0.002
fail_pred_strings                                 0.000    1/2       0.000    1/4       0.000    1/2       0.000    1/4       0.000    1/3       0.000    2/5       0.000  0.000
fold_left fold_right                              0.000   25/74      0.000   22/73      0.003   43/161     0.011   58/139     0.001   17/45      0.000   39/95      0.004  0.012
fold_left fold_right uncurried                    4.361  111/99424   0.054  325/984     0.141   36/304    15.278 4811/8969    0.000    5/19      0.000    2/13      4.502 15.332
fold_left fold_right uncurried fun last           0.000   26/89      0.000   25/86      0.004   42/136     0.003   54/176     0.000   16/52      0.000   40/93      0.004  0.004
fold_left test, fun first                         0.002   40/57      0.001   15/28     28.631  125/27750   5.639   45/11947  20.790  282/87674   1.635  168/27748  49.423  7.276
                                                                                                                                                                   94.186 46.951
```
