### PR TITLE
fix Gen.{nat,pos}_split{2,}

### DIFF
--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -467,14 +467,14 @@ module Gen : sig
 
       This is useful to split sizes to combine sized generators.
 
-      @raise Invalid_argument unless [n >= 2].
-
       @since 0.18
   *)
 
   val pos_split2 : int -> (int * int) t
-  (** [nat_split2 n] generates pairs [(n1, n2)] of strictly positive
+  (** [pos_split2 n] generates pairs [(n1, n2)] of strictly positive
       (nonzero) natural numbers with [n1 + n2 = n].
+
+      @raise Invalid_argument unless [n >= 2].
 
       This is useful to split sizes to combine sized generators.
 
@@ -482,7 +482,7 @@ module Gen : sig
   *)
 
   val nat_split : size:int -> int -> int array t
-  (** [nat_split2 ~size:k n] generates [k]-sized arrays [n1,n2,..nk]
+  (** [nat_split ~size:k n] generates [k]-sized arrays [n1,n2,..nk]
       of natural numbers in [[0;n]] with [n1 + n2 + ... + nk = n].
 
       This is useful to split sizes to combine sized generators.
@@ -493,7 +493,7 @@ module Gen : sig
   *)
 
   val pos_split : size:int -> int -> int array t
-  (** [nat_split2 ~size:k n] generates [k]-sized arrays [n1,n2,..nk]
+  (** [pos_split ~size:k n] generates [k]-sized arrays [n1,n2,..nk]
       of strictly positive (non-zero) natural numbers with
       [n1 + n2 + ... + nk = n].
 
@@ -501,7 +501,7 @@ module Gen : sig
 
       Complexity O(k log k).
 
-      @raise Invalid_argument unless [k <= n].
+      @raise Invalid_argument unless [0 < k <= n] or [0 = k = n].
 
       @since 0.18
   *)

--- a/test/core/qcheck_output.txt.expected
+++ b/test/core/qcheck_output.txt.expected
@@ -863,7 +863,7 @@ stats dist:
    4150517416584649600.. 4611686018427387903: #################                                               189
 ================================================================================
 1 warning(s)
-failure (26 tests failed, 1 tests errored, ran 66 tests)
+failure (26 tests failed, 1 tests errored, ran 71 tests)
 random seed: 153870556
 
 +++ Stats for int_dist_empty_bucket ++++++++++++++++++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
This is a fix for several bugs reported in #180.

Those functions (and `range_subset`), implemented by myself in #114, were utter garbage. I had tested their implementation heavily within a different random library, and when I ported them to QCheck it seems that I messed things up considerably (this is fiddly code full of off-by-one traps etc.).

In the present PR I have gone over the implementation of each function and done some manual testing, and I also wrote automated tests in the existing QCheck testsuite. (This forced me to think about the valid input space for the combinators; I extended `pos_split` to support the case `size=0, n=0`, and found a treacherous bug when `size=1`.)

My recommendation for the future would be to encourage new generators to come with their tests.

Sorry for the mess, and thanks @max-lang for the report!