### PR TITLE
Deriver: fix recursive poly variants derivation

### DIFF
--- a/src/ppx_deriving_qcheck/README.md
+++ b/src/ppx_deriving_qcheck/README.md
@@ -261,7 +261,22 @@ type tree = [ `Leaf of int | `Node of tree * tree ]
 
 (* ==> *)
 
-/!\ FIXME: https://github.com/vch9/ppx_deriving_qcheck/issues/7 /!\
+let gen_tree =
+  (QCheck.Gen.sized @@ QCheck.Gen.fix (fun self -> function
+  | 0 ->
+    QCheck.Gen.frequency [
+	  ( 1, QCheck.Gen.map (fun gen0 -> `Leaf gen0) QCheck.Gen.int);
+    ]
+  | n ->
+    QCheck.Gen.frequency [
+      ( 1, QCheck.Gen.map (fun gen0 -> `Leaf gen0) QCheck.Gen.int);
+      ( 1,
+           QCheck.Gen.map (fun gen0 -> `Node gen0)
+             (QCheck.Gen.map
+               (fun (gen0, gen1) -> (gen0, gen1))
+                 (QCheck.Gen.pair (self (n / 2)) (self (n / 2)))))
+                      ])
+            : tree QCheck.Gen.t)
 ```
 
 ## Mutual recursive types

--- a/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
+++ b/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
@@ -347,6 +347,7 @@ and gen_from_variant ~loc typ_name rws =
   *)
   let gen = sized ~loc ~env:TypeGen.empty typ_name is_rec to_gen rws in
   let typ_t = A.ptyp_constr (A.Located.mk @@ Lident typ_name) [] in
+  (* TODO: mutualize this ident for https://github.com/c-cube/qcheck/issues/190 *)
   let typ_gen = A.Located.mk @@ Lident "QCheck.Gen.t" in
   let typ = A.ptyp_constr typ_gen [ typ_t ] in
   [%expr ([%e gen] : [%t typ])]


### PR DESCRIPTION
Fixes #187 

Before this MR:
```ocaml
type tree = [ `Leaf of int | `Node of tree * tree ]
[@@deriving qcheck]


let gen_tree =
  (QCheck.Gen.frequency
     [(1, (QCheck.Gen.map (fun gen0 -> `Leaf gen0) QCheck.Gen.int));
      (1,
         (QCheck.Gen.map (fun gen0 -> `Node gen0)
         (QCheck.Gen.map (fun (gen0, gen1) -> (gen0, gen1))
         (QCheck.Gen.pair gen_tree gen_tree))))] : tree QCheck.Gen.t)
```

With this MR:
```ocaml
type tree = [ `Leaf of int | `Node of tree * tree ]
[@@deriving qcheck]

let gen_tree =
  (QCheck.Gen.sized @@ QCheck.Gen.fix (fun self -> function
     | 0 -> QCheck.Gen.frequency [(1, QCheck.Gen.map (fun gen0 -> `Leaf gen0) QCheck.Gen.int)]
     | n -> QCheck.Gen.frequency [
                        ( 1, QCheck.Gen.map` (fun gen0 -> `Leaf gen0) QCheck.Gen.int );
                        ( 1,
                          QCheck.Gen.map
                            (fun gen0 -> `Node gen0)
                            (QCheck.Gen.map
                               (fun (gen0, gen1) -> (gen0, gen1))
                               (QCheck.Gen.pair (self (n / 2)) (self (n / 2))))
                        );
                      ])
            : tree QCheck.Gen.t)
```

This was added as a non-regression test.
