### PR TITLE
Add regression tests for qualified type

### DIFF
--- a/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
+++ b/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
@@ -58,7 +58,7 @@ let gen ~loc ?(env = TypeGen.empty) lg =
   match lg with
   | Lident s ->
       Option.value ~default:(name s |> A.evar) @@ TypeGen.find_opt s env
-  | Ldot (lg, s) -> A.(pexp_construct (Located.mk @@ Ldot (lg, name s)) None)
+  | Ldot (lg, s) -> A.(pexp_ident (Located.mk @@ Ldot (lg, name s)))
   | Lapply (_, _) -> raise (Invalid_argument "gen received an Lapply")
 
 let frequency ~loc l = [%expr QCheck.Gen.frequency [%e l]]

--- a/test/ppx_deriving_qcheck/deriver/dune
+++ b/test/ppx_deriving_qcheck/deriver/dune
@@ -1,4 +1,11 @@
 (test
  (name test)
+ (modules test)
  (libraries alcotest ppxlib ppx_deriving_qcheck qcheck)
  (preprocess (pps ppxlib.metaquot)))
+
+(test
+ (name test_qualified_names)
+ (modules test_qualified_names)
+ (libraries qcheck)
+ (preprocess (pps ppx_deriving_qcheck)))

--- a/test/ppx_deriving_qcheck/deriver/test_qualified_names.ml
+++ b/test/ppx_deriving_qcheck/deriver/test_qualified_names.ml
@@ -1,0 +1,7 @@
+module Q = struct
+   type t = int
+    [@@deriving qcheck]
+end
+
+type t = Q.t
+ [@@deriving qcheck]


### PR DESCRIPTION
Qualified type are currently concatenated into a unique identifier, so it becomes a constructor:

```ocaml
module Q = struct
   type t = int
    [@@deriving qcheck]
end

type t = Q.t
 [@@deriving qcheck]
```

```
dune runtest
File "test/ppx_deriving_qcheck/deriver/test_qualified_names.ml", lines 6-7, characters 0-20:
6 | type t = Q.t
7 |  [@@deriving qcheck]
Error: Unbound constructor Q.gen
```

I added the test outside `test.ml`because string comparison doesn't show the difference (`let gen = Q.gen` in both case). I tried to see if the bug was obvious but I haven't found anything.