### PR TITLE
CI fix for Alcotest whitespace changes

### DIFF
--- a/example/alcotest/output.txt.expected
+++ b/example/alcotest/output.txt.expected
@@ -1,22 +1,14 @@
 qcheck random seed: 1234
 Testing `my test'.
-
   [OK]          suite          0   list_rev_is_involutive.
 > [FAIL]        suite          1   fail_sort_id.
   [FAIL]        suite          2   error_raise_exn.
   [FAIL]        suite          3   fail_check_err_message.
   [OK]          suite          4   tree_rev_is_involutive.
-
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite          1   fail_sort_id.                               │
 └──────────────────────────────────────────────────────────────────────────────┘
-
 test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 20 shrink steps)
-                                           
 [exception] test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 20 shrink steps)
-                                           
-            
-
  ──────────────────────────────────────────────────────────────────────────────
-
 3 failures! 5 tests run.

--- a/example/alcotest/run_alcotest.sh
+++ b/example/alcotest/run_alcotest.sh
@@ -11,5 +11,7 @@ echo "$OUT" | grep -v 'This run has ID' \
   | grep -v 'Logs saved to' \
   | grep -v 'Raised at ' \
   | grep -v 'Called from ' \
-  | sed 's/! in .*s\./!/'
+  | sed 's/! in .*s\./!/' \
+  | sed 's/[ \t]*$//g' \
+  | tr -s "\n"
 exit $CODE


### PR DESCRIPTION
This contains the fix proposed in #193.
I have checked that it is OK locally with Alcotest 1.3.0, 1.4.0, 1.5.0. YMMV 🙃