### PR TITLE
Deriver: more tests and some fixes

### DIFF
--- a/src/ppx_deriving_qcheck/QCheck_generators.ml
+++ b/src/ppx_deriving_qcheck/QCheck_generators.ml
@@ -21,11 +21,11 @@ let bool loc = [%expr QCheck.Gen.bool]
 
 let float loc = [%expr QCheck.Gen.float]
 
-let int32 loc = [%expr QCheck.Gen.int32]
+let int32 loc = [%expr QCheck.Gen.ui32]
 
-let int64 loc = [%expr QCheck.Gen.int64]
+let int64 loc = [%expr QCheck.Gen.ui64]
 
-let option ~loc e = [%expr QCheck.Gen.option [%e e]]
+let option ~loc e = [%expr QCheck.Gen.opt [%e e]]
 
 let list ~loc e = [%expr QCheck.Gen.list [%e e]]
 

--- a/src/ppx_deriving_qcheck/QCheck_generators.ml
+++ b/src/ppx_deriving_qcheck/QCheck_generators.ml
@@ -5,7 +5,7 @@ open Ppxlib
 
 (** {2. Type} *)
 
-let ty = "QCheck.Gen.t"
+let ty = Ldot (Ldot (Lident "QCheck", "Gen"), "t")
 
 (** {2. Primitive generators} *)
 

--- a/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
+++ b/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
@@ -318,7 +318,7 @@ and gen_from_variant ~loc ~env rws =
   in
   let gen = gen_sized ~loc is_rec to_gen rws in
   let typ_t = A.ptyp_constr (A.Located.mk @@ Lident env.curr_type) [] in
-  let typ_gen = A.Located.mk @@ Lident G.ty in
+  let typ_gen = A.Located.mk G.ty in
   let typ = A.ptyp_constr typ_gen [ typ_t ] in
   [%expr ([%e gen] : [%t typ])]
 

--- a/test/ppx_deriving_qcheck/deriver/dune
+++ b/test/ppx_deriving_qcheck/deriver/dune
@@ -4,6 +4,7 @@
    test_primitives
    test_qualified_names
    test_recursive
-   test_tuple)
+   test_tuple
+   test_variants)
  (libraries qcheck-alcotest ppxlib ppx_deriving_qcheck qcheck)
  (preprocess (pps ppxlib.metaquot ppx_deriving_qcheck)))

--- a/test/ppx_deriving_qcheck/deriver/dune
+++ b/test/ppx_deriving_qcheck/deriver/dune
@@ -2,6 +2,7 @@
  (names
    test_textual
    test_primitives
-   test_qualified_names)
+   test_qualified_names
+   test_recursive)
  (libraries qcheck-alcotest ppxlib ppx_deriving_qcheck qcheck)
  (preprocess (pps ppxlib.metaquot ppx_deriving_qcheck)))

--- a/test/ppx_deriving_qcheck/deriver/dune
+++ b/test/ppx_deriving_qcheck/deriver/dune
@@ -1,11 +1,7 @@
-(test
- (name test)
- (modules test)
- (libraries alcotest ppxlib ppx_deriving_qcheck qcheck)
- (preprocess (pps ppxlib.metaquot)))
-
-(test
- (name test_qualified_names)
- (modules test_qualified_names)
- (libraries qcheck)
- (preprocess (pps ppx_deriving_qcheck)))
+(tests
+ (names
+   test_textual
+   test_primitives
+   test_qualified_names)
+ (libraries qcheck-alcotest ppxlib ppx_deriving_qcheck qcheck)
+ (preprocess (pps ppxlib.metaquot ppx_deriving_qcheck)))

--- a/test/ppx_deriving_qcheck/deriver/dune
+++ b/test/ppx_deriving_qcheck/deriver/dune
@@ -5,6 +5,7 @@
    test_qualified_names
    test_recursive
    test_tuple
-   test_variants)
+   test_variants
+   test_record)
  (libraries qcheck-alcotest ppxlib ppx_deriving_qcheck qcheck)
  (preprocess (pps ppxlib.metaquot ppx_deriving_qcheck)))

--- a/test/ppx_deriving_qcheck/deriver/dune
+++ b/test/ppx_deriving_qcheck/deriver/dune
@@ -3,6 +3,7 @@
    test_textual
    test_primitives
    test_qualified_names
-   test_recursive)
+   test_recursive
+   test_tuple)
  (libraries qcheck-alcotest ppxlib ppx_deriving_qcheck qcheck)
  (preprocess (pps ppxlib.metaquot ppx_deriving_qcheck)))

--- a/test/ppx_deriving_qcheck/deriver/helpers.ml
+++ b/test/ppx_deriving_qcheck/deriver/helpers.ml
@@ -1,0 +1,15 @@
+open QCheck
+
+(** {1. Helpers} *)
+
+let seed = [| 42 |]
+
+let generate gen = Gen.generate ~n:20 ~rand:(Random.State.make seed) gen
+
+(** [test_compare msg eq gen_ref gen_cand] will generate with the same seed
+    [gen_ref] and [gen_cand], and test with Alcotest that both generators
+    generates the same values. *)
+let test_compare ~msg ~eq gen_ref gen_candidate =
+  let expected = generate gen_ref in
+  let actual = generate gen_candidate in
+  Alcotest.(check (list eq)) msg expected actual

--- a/test/ppx_deriving_qcheck/deriver/test_primitives.ml
+++ b/test/ppx_deriving_qcheck/deriver/test_primitives.ml
@@ -1,0 +1,89 @@
+open QCheck
+open Helpers
+
+(** {1. Test primitives derivation} *)
+
+(** {2. Tests} *)
+
+type int' = int [@@deriving qcheck]
+
+let test_int () =
+  test_compare ~msg:"Gen.int <=> deriving int" ~eq:Alcotest.int Gen.int gen_int'
+
+type unit' = unit [@@deriving qcheck]
+
+(* Pretty useless though, but, meh *)
+let test_unit () =
+  test_compare ~msg:"Gen.unit <=> deriving unit" ~eq:Alcotest.unit Gen.unit gen_unit'
+
+type string' = string [@@deriving qcheck]
+
+let test_string () =
+  test_compare ~msg:"Gen.string <=> deriving string" ~eq:Alcotest.string Gen.string gen_string'
+
+type char' = char [@@deriving qcheck]
+
+let test_char () =
+  test_compare ~msg:"Gen.char <=> deriving char" ~eq:Alcotest.char Gen.char gen_char'
+
+type bool' = bool [@@deriving qcheck]
+
+let test_bool () =
+  test_compare ~msg:"Gen.bool <=> deriving bool" ~eq:Alcotest.bool Gen.bool gen_bool'
+
+type float' = float [@@deriving qcheck]
+
+let test_float () =
+  test_compare ~msg:"Gen.float <=> deriving float" ~eq:(Alcotest.float 0.) Gen.float gen_float'
+
+type int32' = int32 [@@deriving qcheck]
+
+let test_int32 () =
+  test_compare ~msg:"Gen.int32 <=> deriving int32" ~eq:Alcotest.int32 Gen.ui32 gen_int32'
+
+type int64' = int64 [@@deriving qcheck]
+
+let test_int64 () =
+  test_compare ~msg:"Gen.int64 <=> deriving int64" ~eq:Alcotest.int64 Gen.ui64 gen_int64'
+
+type 'a option' = 'a option [@@deriving qcheck]
+
+let test_option () =
+  let zero = Gen.pure 0 in
+  test_compare ~msg:"Gen.opt <=> deriving opt"
+    ~eq:Alcotest.(option int)
+    (Gen.opt zero) (gen_option' zero)
+
+type 'a array' = 'a array [@@deriving qcheck]
+
+let test_array () =
+  let zero = Gen.pure 0 in
+  test_compare ~msg:"Gen.array <=> deriving array"
+    ~eq:Alcotest.(array int)
+    (Gen.array zero) (gen_array' zero)
+
+type 'a list' = 'a list [@@deriving qcheck]
+
+let test_list () =
+  let zero = Gen.pure 0 in
+  test_compare ~msg:"Gen.list <=> deriving list"
+    ~eq:Alcotest.(list int)
+    (Gen.list zero) (gen_list' zero)
+
+(** {2. Execute tests} *)
+
+let () = Alcotest.run "Test_Primitives"
+           [("Primitives",
+             Alcotest.[
+                 test_case "test_int" `Quick test_int;
+                 test_case "test_unit" `Quick test_unit;
+                 test_case "test_string" `Quick test_string;
+                 test_case "test_char" `Quick test_char;
+                 test_case "test_bool" `Quick test_bool;
+                 test_case "test_float" `Quick test_float;
+                 test_case "test_int32" `Quick test_int32;
+                 test_case "test_int64" `Quick test_int64;
+                 test_case "test_option" `Quick test_option;
+                 test_case "test_array" `Quick test_array;
+                 test_case "test_list" `Quick test_list;
+           ])]

--- a/test/ppx_deriving_qcheck/deriver/test_record.ml
+++ b/test/ppx_deriving_qcheck/deriver/test_record.ml
@@ -1,12 +1,65 @@
-type t = {
+open QCheck
+open Helpers
+
+type env = {
     rec_types : string list;
     curr_types : string list;
     curr_type : string
   }
 [@@deriving qcheck]
 
+let pp_env fmt {rec_types; curr_types; curr_type} =
+  let open Format in
+  fprintf fmt {|{
+  rec_types = [%a];
+  curr_types = [%a];
+  curr_type = [%s];
+}|}
+    (pp_print_list pp_print_string) rec_types
+    (pp_print_list pp_print_string) curr_types
+    curr_type
+
+let eq_env = Alcotest.of_pp pp_env
+
+let gen_env_ref =
+  let open Gen in
+  map3 (fun rec_types curr_types curr_type ->
+      { rec_types; curr_types; curr_type })
+    (list string) (list string) string
+
+let test_env () =
+  test_compare ~msg:"gen_env ref <=> deriving env"
+  ~eq:eq_env gen_env_ref gen_env
+
 type color = Color of { red : float; green : float; blue : float }
 [@@deriving qcheck]
 
-(* TODO: use these types to test generated values inside records.
-   For now, having these ensure the compilation *)
+let pp_color fmt (Color {red; green; blue}) =
+  let open Format in
+  fprintf fmt {|Color {
+  red = %a;
+  green = %a;
+  blue = %a;
+}|}
+    pp_print_float red
+    pp_print_float green
+    pp_print_float blue
+
+let eq_color = Alcotest.of_pp pp_color
+
+let gen_color_ref =
+  let open Gen in
+  map3 (fun red green blue -> Color {red; green; blue}) float float float
+
+let test_color () =
+  test_compare ~msg:"gen_color ref <=> deriving color"
+  ~eq:eq_color gen_color_ref gen_color
+
+(** {2. Execute tests} *)
+
+let () = Alcotest.run "Test_Record"
+           [("Record",
+             Alcotest.[
+                 test_case "test_env" `Quick test_env;
+                 test_case "test_color" `Quick test_color;
+           ])]

--- a/test/ppx_deriving_qcheck/deriver/test_record.ml
+++ b/test/ppx_deriving_qcheck/deriver/test_record.ml
@@ -1,0 +1,12 @@
+type t = {
+    rec_types : string list;
+    curr_types : string list;
+    curr_type : string
+  }
+[@@deriving qcheck]
+
+type color = Color of { red : float; green : float; blue : float }
+[@@deriving qcheck]
+
+(* TODO: use these types to test generated values inside records.
+   For now, having these ensure the compilation *)

--- a/test/ppx_deriving_qcheck/deriver/test_recursive.ml
+++ b/test/ppx_deriving_qcheck/deriver/test_recursive.ml
@@ -1,0 +1,80 @@
+open QCheck
+open Helpers
+
+type 'a tree = Leaf | Node of 'a * 'a tree * 'a tree
+[@@deriving qcheck]
+
+let rec pp_tree pp fmt x =
+  let open Format in
+  match x with
+  | Leaf ->
+     fprintf fmt "Leaf"
+  | Node (x, l, r) ->
+     fprintf fmt "Node (%a, %a, %a)"
+       pp x
+       (pp_tree pp) l
+       (pp_tree pp) r
+
+let eq_tree pp = Alcotest.of_pp (pp_tree pp)
+
+let gen_tree_ref gen =
+  let open Gen in
+  sized @@ fix (fun self ->
+             function
+             | 0 -> pure Leaf
+             | n ->
+                oneof [
+                    pure Leaf;
+                    map3 (fun x l r -> Node (x,l,r)) gen (self (n/2)) (self (n/2));
+             ])
+
+let gen_tree_candidate = gen_tree
+
+let test_tree_ref () =
+  let gen = Gen.int in
+  test_compare ~msg:"gen tree <=> derivation tree"
+    ~eq:(eq_tree Format.pp_print_int)
+    (gen_tree_ref gen) (gen_tree gen)
+
+let test_leaf =
+  Test.make
+    ~name:"gen_tree_sized 0 = Node (_, Leaf, Leaf)"
+    (make (gen_tree_sized Gen.int 0))
+    (function
+     | Leaf -> true
+     | Node (_, Leaf, Leaf) -> true
+     | _ -> false)
+  |>
+    QCheck_alcotest.to_alcotest
+
+(* A slight error has been found here:
+   If the type is named `list` then `'a list` will be derived with the
+   QCheck generator `list` instead of the `gen_list_sized`.
+
+   This could lead to a design choice:
+   - do we allow overriding primitive types?
+   - do we prioritize `Env.curr_types` over primitive types?
+*)
+type 'a my_list = Cons of 'a * 'a my_list | Nil
+[@@deriving qcheck]
+
+let rec length = function
+  | Nil -> 0
+  | Cons (_, xs) -> 1 + length xs
+
+let test_length =
+  Test.make
+    ~name:"gen_list_sized n >>= fun l -> length l <= n"
+    small_int
+    (fun n ->
+      let l = Gen.(generate1 (gen_my_list_sized Gen.int n)) in
+      length l <= n)
+  |>
+    QCheck_alcotest.to_alcotest
+
+let () = Alcotest.run "Test_Recursive"
+           [("Recursive",
+             Alcotest.[
+                 test_case "test_tree_ref" `Quick test_tree_ref;
+                 test_leaf
+             ])]

--- a/test/ppx_deriving_qcheck/deriver/test_textual.ml
+++ b/test/ppx_deriving_qcheck/deriver/test_textual.ml
@@ -55,25 +55,25 @@ let test_bool () =
   check_eq ~expected ~actual "deriving bool"
 
 let test_int32 () =
-  let expected = [ [%stri let gen = QCheck.Gen.int32] ] in
+  let expected = [ [%stri let gen = QCheck.Gen.ui32] ] in
   let actual = f @@ extract [%stri type t = int32] in
 
   check_eq ~expected ~actual "deriving int32"
 
 let test_int32' () =
-  let expected = [ [%stri let gen = QCheck.Gen.int32] ] in
+  let expected = [ [%stri let gen = QCheck.Gen.ui32] ] in
   let actual = f @@ extract [%stri type t = Int32.t] in
 
   check_eq ~expected ~actual "deriving int32'"
 
 let test_int64 () =
-  let expected = [ [%stri let gen = QCheck.Gen.int64] ] in
+  let expected = [ [%stri let gen = QCheck.Gen.ui64] ] in
   let actual = f @@ extract [%stri type t = int64] in
 
   check_eq ~expected ~actual "deriving int64"
 
 let test_int64' () =
-  let expected = [ [%stri let gen = QCheck.Gen.int64] ] in
+  let expected = [ [%stri let gen = QCheck.Gen.ui64] ] in
   let actual = f @@ extract [%stri type t = Int64.t] in
 
   check_eq ~expected ~actual "deriving int64'"
@@ -147,7 +147,7 @@ let test_tuple () =
   check_eq ~expected ~actual "deriving tuples"
 
 let test_option () =
-  let expected = [ [%stri let gen = QCheck.Gen.option QCheck.Gen.int] ] in
+  let expected = [ [%stri let gen = QCheck.Gen.opt QCheck.Gen.int] ] in
   let actual = f' @@ extract' [ [%stri type t = int option] ] in
   check_eq ~expected ~actual "deriving option"
 

--- a/test/ppx_deriving_qcheck/deriver/test_tuple.ml
+++ b/test/ppx_deriving_qcheck/deriver/test_tuple.ml
@@ -1,0 +1,23 @@
+type tup2 = int * int
+[@@deriving qcheck]
+
+type tup3 = int * int * int
+[@@deriving qcheck]
+
+type tup4 = int * int * int * int
+[@@deriving qcheck]
+
+type tup5 = int * int * int * int * int
+[@@deriving qcheck]
+
+type tup6 = int * int * int * int * int * int
+[@@deriving qcheck]
+
+type tup7 = int * int * int * int * int * int * int
+[@@deriving qcheck]
+
+type tup8 = int * int * int * int * int * int * int * int
+[@@deriving qcheck]
+
+(* TODO: use these types to test generated values inside tuples.
+   For now, having these ensure the compilation *)

--- a/test/ppx_deriving_qcheck/deriver/test_tuple.ml
+++ b/test/ppx_deriving_qcheck/deriver/test_tuple.ml
@@ -1,23 +1,106 @@
-type tup2 = int * int
+open QCheck
+
+type a = char [@gen QCheck.Gen.pure 'a']
 [@@deriving qcheck]
 
-type tup3 = int * int * int
+type b = char [@gen QCheck.Gen.pure 'b']
 [@@deriving qcheck]
 
-type tup4 = int * int * int * int
+type c = char [@gen QCheck.Gen.pure 'c']
 [@@deriving qcheck]
 
-type tup5 = int * int * int * int * int
+type d = char [@gen QCheck.Gen.pure 'd']
 [@@deriving qcheck]
 
-type tup6 = int * int * int * int * int * int
+type e = char [@gen QCheck.Gen.pure 'e']
 [@@deriving qcheck]
 
-type tup7 = int * int * int * int * int * int * int
+type f = char [@gen QCheck.Gen.pure 'f']
 [@@deriving qcheck]
 
-type tup8 = int * int * int * int * int * int * int * int
+type g = char [@gen QCheck.Gen.pure 'g']
 [@@deriving qcheck]
 
-(* TODO: use these types to test generated values inside tuples.
-   For now, having these ensure the compilation *)
+type h = char [@gen QCheck.Gen.pure 'h']
+[@@deriving qcheck]
+
+type i = char [@gen QCheck.Gen.pure 'i']
+[@@deriving qcheck]
+
+type tup2 = a * b
+[@@deriving qcheck]
+
+type tup3 = a * b * c
+[@@deriving qcheck]
+
+type tup4 = a * b * c * d
+[@@deriving qcheck]
+
+type tup5 = a * b * c * d * e
+[@@deriving qcheck]
+
+type tup6 = a * b * c * d * e * f
+[@@deriving qcheck]
+
+type tup7 = a * b * c * d * e * f * g
+[@@deriving qcheck]
+
+type tup8 = a * b * c * d * e * f * g * h
+[@@deriving qcheck]
+
+let test_tup2 =
+  Test.make ~count:10
+    ~name:"forall x in ('a', 'b'): x = ('a', 'b')"
+    (make gen_tup2)
+    (fun x -> x = ('a', 'b'))
+
+let test_tup3 =
+  Test.make ~count:10
+    ~name:"forall x in ('a', 'b', 'c'): x = ('a', 'b', 'c')"
+    (make gen_tup3)
+    (fun x -> x = ('a', 'b', 'c'))
+
+let test_tup4 =
+  Test.make ~count:10
+    ~name:"forall x in ('a', 'b', 'c', 'd'): x = ('a', 'b', 'c', 'd')"
+    (make gen_tup4)
+    (fun x -> x = ('a', 'b', 'c', 'd'))
+
+let test_tup5 =
+  Test.make ~count:10
+    ~name:"forall x in ('a', 'b', 'c', 'd', 'e'): x = ('a', 'b', 'c', 'd', 'e')"
+    (make gen_tup5)
+    (fun x -> x = ('a', 'b', 'c', 'd', 'e'))
+
+let test_tup6 =
+  Test.make ~count:10
+    ~name:"forall x in ('a', 'b', 'c', 'd', 'e', 'f'): x = ('a', 'b', 'c', 'd', 'e', 'f')"
+    (make gen_tup6)
+    (fun x -> x = ('a', 'b', 'c', 'd', 'e', 'f'))
+
+let test_tup7 =
+  Test.make ~count:10
+    ~name:"forall x in ('a', 'b', 'c', 'd', 'e', 'f', 'g'): x = ('a', 'b', 'c', 'd', 'e', 'f', 'g')"
+    (make gen_tup7)
+    (fun x -> x = ('a', 'b', 'c', 'd', 'e', 'f', 'g'))
+
+let test_tup8 =
+  Test.make ~count:10
+    ~name:"forall x in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'): x = ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h')"
+    (make gen_tup8)
+    (fun x -> x = ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h'))
+
+let tests = [
+    test_tup2;
+    test_tup3;
+    test_tup4;
+    test_tup5;
+    test_tup6;
+    test_tup7;
+    test_tup8;
+  ]
+
+let tests = List.map (QCheck_alcotest.to_alcotest) tests
+
+(** {2. Execute tests} *)
+let () = Alcotest.run "Test_Tuple" [("Tuple", tests)]

--- a/test/ppx_deriving_qcheck/deriver/test_variants.ml
+++ b/test/ppx_deriving_qcheck/deriver/test_variants.ml
@@ -1,0 +1,81 @@
+open QCheck
+open Helpers
+
+(** {1. Test variants and polymorphic variants derivation} *)
+
+(** {2. Variants} *)
+
+type colors = Red | Green | Blue [@@deriving qcheck]
+
+let pp_colors fmt x =
+  let open Format in
+  match x with
+  | Red -> fprintf fmt "Red"
+  | Green -> fprintf fmt "Green"
+  | Blue -> fprintf fmt "Blue"
+
+let eq_colors = Alcotest.of_pp pp_colors
+
+let gen = Gen.oneofl [Red; Green; Blue]
+
+let test_variants () =
+  test_compare ~msg:"Gen.oneofl <=> deriving variants" ~eq:eq_colors gen gen_colors
+
+type poly_colors = [`Red | `Green | `Blue] [@@deriving qcheck]
+
+let pp_poly_colors fmt x =
+  let open Format in
+  match x with
+  | `Red -> fprintf fmt "`Red"
+  | `Green -> fprintf fmt "`Green"
+  | `Blue -> fprintf fmt "`Blue"
+
+let eq_poly_colors = Alcotest.of_pp pp_poly_colors
+
+let gen_poly : poly_colors Gen.t = Gen.oneofl [`Red; `Green; `Blue]
+
+let test_poly_variants () =
+  test_compare ~msg:"Gen.oneofl <=> deriving variants"
+    ~eq:eq_poly_colors gen_poly gen_poly_colors
+
+(** {2. Tests weight} *)
+
+type letters =
+  | A [@weight 0]
+  | B
+[@@deriving qcheck]
+
+let test_weight =
+  Test.make ~name:"gen_letters always produces B"
+    (make gen_letters)
+    (function
+     | A -> false
+     | B -> true)
+  |>
+    QCheck_alcotest.to_alcotest
+
+type poly_letters = [
+    | `A [@weight 0]
+    | `B
+  ]
+[@@deriving qcheck]
+
+let test_weight_poly =
+  Test.make ~name:"gen_poly_letters always produces B"
+    (make gen_poly_letters)
+    (function
+     | `A -> false
+     | `B -> true)
+  |>
+    QCheck_alcotest.to_alcotest
+
+(** {2. Execute tests} *)
+
+let () = Alcotest.run "Test_Variant"
+           [("Variants",
+             Alcotest.[
+                 test_case "test_variants" `Quick test_variants;
+                 test_case "test_poly_variants" `Quick test_poly_variants;
+                 test_weight;
+                 test_weight_poly
+           ])]


### PR DESCRIPTION
I think #201 raised an issue: textual diff tests are not enough (thank you @bobot)

Therefore, I started writing tests using the derived generators, we can then ensure both:
- The deriver produce a well-typed generator (at least for the types tested)
- The deriver uses the same generators as in QCheck

Thank to these tests, I found little bugs in the code, fixed alongside the tests.

~(Do not mind extra commits, it is for now rebased on #195, If someone review this before the merge of #195, you should
review commit by commit starting 7bf423be7e5a5206636608fb828b850b78904657)~