### PR TITLE
Remove n fuel when its not used

### DIFF
--- a/test/ppx_deriving_qcheck/deriver/test_textual.ml
+++ b/test/ppx_deriving_qcheck/deriver/test_textual.ml
@@ -738,15 +738,32 @@ let test_unused_variable () =
      ];
       [%stri
        let gen_c = QCheck.Gen.sized @@ gen_c_sized
-      ]
+      ];
+      [%stri
+        let rec gen_c_sized _n =
+          QCheck.Gen.frequency
+            [(1, (QCheck.Gen.map (fun gen0 -> A gen0) gen_myint));
+             (1, (QCheck.Gen.map (fun gen0 -> B gen0) gen_myint))]
+        and gen_myint = QCheck.Gen.nat
+      ];
+      [%stri
+       let gen_c = QCheck.Gen.sized @@ gen_c_sized
+      ];
     ]
   in
   let actual =
-    f @@ extract [%stri
-      type c =
-        | A
-        | B of myint
-      and myint = int [@gen QCheck.Gen.nat] ]
+    f' @@ extract' [
+             [%stri
+              type c =
+                | A
+                | B of myint
+              and myint = int [@gen QCheck.Gen.nat] ];
+             [%stri
+              type c =
+                | A of myint
+                | B of myint
+              and myint = int [@gen QCheck.Gen.nat] ];
+           ]
   in
   check_eq ~expected ~actual "deriving variant with unused fuel parameter"
 


### PR DESCRIPTION
#Closes #213 _again_

@jmid I went for your first option:
> I suppose it could be solved by writing a simple occurs n search (unless there is an easier way in ppxlib to check whether an identifier n occurs in a sub-expression) - and simply name it _n if it doesn't occur

I think it's pretty easy to do this kind of stuff with an `Ast_traverse`, some of the code could be refactored used this object (e.g. `is_recursive`).