### PR TITLE
add ?handler parameter to check_cell_exn

### DIFF
--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -1059,7 +1059,8 @@ module Test : sig
     ?rand:Random.State.t -> 'a cell -> 'a TestResult.t
 
   val check_cell_exn :
-    ?long:bool -> ?call:'a callback -> ?step:'a step ->
+    ?long:bool -> ?call:'a callback ->
+    ?step:'a step -> ?handler:'a handler ->
     ?rand:Random.State.t -> 'a cell -> unit
 
   val check_exn : ?long:bool -> ?rand:Random.State.t -> t -> unit

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -1931,8 +1931,8 @@ module Test = struct
     | R.Failed_other {msg} ->
       raise (Test_fail (cell.name, [msg]))
 
-  let check_cell_exn ?long ?call ?step ?rand cell =
-    let res = check_cell ?long ?call ?step ?rand cell in
+  let check_cell_exn ?long ?call ?step ?handler ?rand cell =
+    let res = check_cell ?long ?call ?step ?handler ?rand cell in
     check_result cell res
 
   let check_exn ?long ?rand (Test cell) = check_cell_exn ?long ?rand cell

--- a/src/core/QCheck2.mli
+++ b/src/core/QCheck2.mli
@@ -1741,7 +1741,8 @@ module Test : sig
   *)
 
   val check_cell_exn :
-    ?long:bool -> ?call:'a callback -> ?step:'a step ->
+    ?long:bool -> ?call:'a callback ->
+    ?step:'a step -> ?handler:'a handler ->
     ?rand:Random.State.t -> 'a cell -> unit
   (** Same as {!check_cell} but calls  {!check_result} on the result.
       @raise Test_error if [res = Error _]


### PR DESCRIPTION
The parameter ?handler was added late to check_cell, and is missing
from its check_cell_exn counterpart for no good reason.

I hit this discrepancy when trying to debug a shrinker from within a Qcheck_alcotest test.