### PR TITLE
Alcotest: debug_shrink

### DIFF
--- a/example/alcotest/QCheck_alcotest_test.ml
+++ b/example/alcotest/QCheck_alcotest_test.ml
@@ -55,6 +55,6 @@ let () =
     List.map QCheck_alcotest.to_alcotest
       [ passing; failing; error; simple_qcheck; passing_tree_rev ]
   in
-  A.run "my test" [
-    "suite", suite
-  ]
+  A.run ~show_errors:true "my test" [
+    "suite", suite;
+  ];

--- a/example/alcotest/QCheck_alcotest_test.ml
+++ b/example/alcotest/QCheck_alcotest_test.ml
@@ -48,6 +48,13 @@ let passing_tree_rev =
     QCheck.(make gen_tree)
     (fun tree -> rev_tree (rev_tree tree) = tree)
 
+let debug_shrink =
+  QCheck.Test.make ~count:10
+    ~name:"debug_shrink"
+    (* we use a very constrained test to have a smaller shrinking tree *)
+    QCheck.(pair (1 -- 3) (1 -- 3))
+    (fun (a, b) -> a = b);;
+
 let () =
   Printexc.record_backtrace true;
   let module A = Alcotest in
@@ -57,4 +64,7 @@ let () =
   in
   A.run ~show_errors:true "my test" [
     "suite", suite;
+    "shrinking", [
+      QCheck_alcotest.to_alcotest ~verbose:true ~debug_shrink:(Some stdout) debug_shrink
+    ];
   ];

--- a/example/alcotest/output.txt.expected
+++ b/example/alcotest/output.txt.expected
@@ -1,7 +1,7 @@
 qcheck random seed: 1234
 Testing `my test'.
   [OK]          suite          0   list_rev_is_involutive.
-> [FAIL]        suite          1   fail_sort_id.
+  [FAIL]        suite          1   fail_sort_id.
   [FAIL]        suite          2   error_raise_exn.
   [FAIL]        suite          3   fail_check_err_message.
   [OK]          suite          4   tree_rev_is_involutive.
@@ -10,5 +10,31 @@ Testing `my test'.
 └──────────────────────────────────────────────────────────────────────────────┘
 test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 20 shrink steps)
 [exception] test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 20 shrink steps)
+ ──────────────────────────────────────────────────────────────────────────────
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [FAIL]        suite          2   error_raise_exn.                            │
+└──────────────────────────────────────────────────────────────────────────────┘
+test `error_raise_exn`
+raised exception `Error`
+on `0 (after 63 shrink steps)`
+[exception] test `error_raise_exn`
+raised exception `Error`
+on `0 (after 63 shrink steps)`
+ ──────────────────────────────────────────────────────────────────────────────
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [FAIL]        suite          3   fail_check_err_message.                     │
+└──────────────────────────────────────────────────────────────────────────────┘
+test `fail_check_err_message` failed on ≥ 1 cases:
+0 (after 7 shrink steps)
+this
+will
+always
+fail
+[exception] test `fail_check_err_message` failed on ≥ 1 cases:
+0 (after 7 shrink steps)
+this
+will
+always
+fail
  ──────────────────────────────────────────────────────────────────────────────
 3 failures! 5 tests run.

--- a/example/alcotest/output.txt.expected
+++ b/example/alcotest/output.txt.expected
@@ -1,18 +1,19 @@
 qcheck random seed: 1234
 Testing `my test'.
-  [OK]          suite          0   list_rev_is_involutive.
-  [FAIL]        suite          1   fail_sort_id.
-  [FAIL]        suite          2   error_raise_exn.
-  [FAIL]        suite          3   fail_check_err_message.
-  [OK]          suite          4   tree_rev_is_involutive.
+  [OK]          suite              0   list_rev_is_involutive.
+  [FAIL]        suite              1   fail_sort_id.
+  [FAIL]        suite              2   error_raise_exn.
+  [FAIL]        suite              3   fail_check_err_message.
+  [OK]          suite              4   tree_rev_is_involutive.
+  [FAIL]        shrinking          0   debug_shrink.
 ┌──────────────────────────────────────────────────────────────────────────────┐
-│ [FAIL]        suite          1   fail_sort_id.                               │
+│ [FAIL]        suite              1   fail_sort_id.                           │
 └──────────────────────────────────────────────────────────────────────────────┘
 test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 20 shrink steps)
 [exception] test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 20 shrink steps)
  ──────────────────────────────────────────────────────────────────────────────
 ┌──────────────────────────────────────────────────────────────────────────────┐
-│ [FAIL]        suite          2   error_raise_exn.                            │
+│ [FAIL]        suite              2   error_raise_exn.                        │
 └──────────────────────────────────────────────────────────────────────────────┘
 test `error_raise_exn`
 raised exception `Error`
@@ -22,7 +23,7 @@ raised exception `Error`
 on `0 (after 63 shrink steps)`
  ──────────────────────────────────────────────────────────────────────────────
 ┌──────────────────────────────────────────────────────────────────────────────┐
-│ [FAIL]        suite          3   fail_check_err_message.                     │
+│ [FAIL]        suite              3   fail_check_err_message.                 │
 └──────────────────────────────────────────────────────────────────────────────┘
 test `fail_check_err_message` failed on ≥ 1 cases:
 0 (after 7 shrink steps)
@@ -37,4 +38,23 @@ will
 always
 fail
  ──────────────────────────────────────────────────────────────────────────────
-3 failures! 5 tests run.
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ [FAIL]        shrinking          0   debug_shrink.                           │
+└──────────────────────────────────────────────────────────────────────────────┘
+~~~ Shrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Test debug_shrink successfully shrunk counter example (step 0) to:
+(3, 1)
+~~~ Shrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Test debug_shrink successfully shrunk counter example (step 1) to:
+(2, 1)
+~~~ Shrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Test debug_shrink successfully shrunk counter example (step 2) to:
+(2, 0)
+~~~ Shrink ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Test debug_shrink successfully shrunk counter example (step 3) to:
+(1, 0)
+law debug_shrink: 2 relevant cases (2 total)
+test `debug_shrink` failed on ≥ 1 cases: (1, 0) (after 3 shrink steps)
+[exception] test `debug_shrink` failed on ≥ 1 cases: (1, 0) (after 3 shrink steps)
+ ──────────────────────────────────────────────────────────────────────────────
+4 failures! 6 tests run.

--- a/example/alcotest/run_alcotest.sh
+++ b/example/alcotest/run_alcotest.sh
@@ -12,6 +12,7 @@ echo "$OUT" | grep -v 'This run has ID' \
   | grep -v 'Raised at ' \
   | grep -v 'Called from ' \
   | sed 's/! in .*s\./!/' \
+  | sed 's/`.*.Error`/`Error`/g' \
   | sed 's/[ \t]*$//g' \
   | tr -s "\n"
 exit $CODE

--- a/src/alcotest/QCheck_alcotest.mli
+++ b/src/alcotest/QCheck_alcotest.mli
@@ -12,7 +12,10 @@
 *)
 
 val to_alcotest :
-  ?verbose:bool -> ?long:bool -> ?rand:Random.State.t ->
+  ?colors:bool -> ?verbose:bool -> ?long:bool ->
+  ?debug_shrink:(out_channel option) ->
+  ?debug_shrink_list:(string list) ->
+  ?rand:Random.State.t ->
   QCheck2.Test.t -> unit Alcotest.test_case
 (** Convert a qcheck test into an alcotest test
     @param verbose used to print information on stdout (default: [verbose()])

--- a/src/runner/QCheck_base_runner.mli
+++ b/src/runner/QCheck_base_runner.mli
@@ -87,6 +87,16 @@ type handler_gen =
 val default_handler : handler_gen
 (** The default handler used. *)
 
+val debug_shrinking_choices:
+  colors:bool ->
+  out:out_channel ->
+  name:string -> 'a QCheck2.Test.cell -> step:int -> 'a -> unit
+(** The function used by the default handler to debug shrinking choices.
+    This can be useful to outside users trying to reproduce some of the
+    base-runner behavior.
+
+    @since 0.19
+*)
 
 (** {2 Run a Suite of Tests and Get Results} *)
 


### PR DESCRIPTION
This PR sits on top of #216; it implements a `debug_shrink` option for `QCheck_alcotest.to_alcotest`, allowing QCheck_alcotest users to debug their shrinkers.

I would consider this an important feature for QCheck_alcotest users: it's not possible in practice to develop your own shrinkers if you cannot debug the shrinker.