### PR TITLE
make test: remove the --no-buffer option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	@dune build @install
 
 test:
-	@dune runtest --no-buffer --force
+	@dune runtest --force
 
 clean:
 	@dune clean


### PR DESCRIPTION
On my machine, the test output would previously be garbled in various
ways. For example:

    Done: 230/237 (jobs: 5)Testing `Test_Primitives'.
    This run has ID `O6P0L2KW'.

      [OK]          Primitives          0   test_int.
      [OK]          Primitives          1   test_unit.
      [OK]          Primitives          2   test_string.
      [OK]          Primitives          3   test_char.
      [OK]          Primitives          4   test_bool.
      [OK]          Primitives          5   test_float.
      [OK]          Primitives          6   test_int32.
      [OK]          Primitives          7   test_int64.
      [OK]          Primitives          8   test_option.
      [OK]          Primitives          9   test_array.
      ...           Primitives         10   test_list.Testing `Test_Qualified_names'.
    This run has ID `G59X8MGJ'.

      [OK]          Qualified names          0   test_module.
      [OK]          Primitives         10   test_list.functor.

    Full test results in `~/Prog/ocaml/qcheck/_build/default/test/ppx_deriving_qcheck/deriver/_build/_tests/Test_Primitives'.
    Test Successful in 0.005s. 11 tests run.
      [OK]          Qualified names          1   test_functor.

    Full test results in `~/Prog/ocaml/qcheck/_build/default/test/ppx_deriving_qcheck/deriver/_build/_tests/Test_Qualified_names'.
    Test Successful in 0.000s. 2 tests run.
    Done: 231/237 (jobs: 4)qcheck random seed: 786226726
    Done: 232/237 (jobs: 3)Testing `Test_Recursive'.

(This gets even more confusing when some of the tests fail.)