### PR TITLE
Chore: Align expect test suites by reordering

### DIFF
--- a/test/core/QCheck2_expect_test.expected
+++ b/test/core/QCheck2_expect_test.expected
@@ -428,6 +428,54 @@ Test quadruples are ordered reversely failed (66 shrink steps):
 
 --- Failure --------------------------------------------------------------------
 
+Test forall (a, b) in nat: a < b failed (6 shrink steps):
+
+(0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c) in nat: a < b < c failed (3 shrink steps):
+
+(0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c, d) in nat: a < b < c < d failed (4 shrink steps):
+
+(0, 0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c, d, e) in nat: a < b < c < d < e failed (5 shrink steps):
+
+(0, 0, 0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c, d, e, f) in nat: a < b < c < d < e < f failed (6 shrink steps):
+
+(0, 0, 0, 0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c, d, e, f, g) in nat: a < b < c < d < e < f < g failed (7 shrink steps):
+
+(0, 0, 0, 0, 0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c, d, e, f, g, h) in nat: a < b < c < d < e < f < g < h failed (8 shrink steps):
+
+(0, 0, 0, 0, 0, 0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c, d, e, f, g, h, i) in nat: a < b < c < d < e < f < g < h < i failed (9 shrink steps):
+
+(0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
 Test bind ordered pairs failed (1 shrink steps):
 
 (0, 0)
@@ -479,54 +527,6 @@ Test lists have unique elems failed (11 shrink steps):
 Test tree contains only 42 failed (2 shrink steps):
 
 Leaf 0
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b) in nat: a < b failed (6 shrink steps):
-
-(0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c) in nat: a < b < c failed (3 shrink steps):
-
-(0, 0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c, d) in nat: a < b < c < d failed (4 shrink steps):
-
-(0, 0, 0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c, d, e) in nat: a < b < c < d < e failed (5 shrink steps):
-
-(0, 0, 0, 0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c, d, e, f) in nat: a < b < c < d < e < f failed (6 shrink steps):
-
-(0, 0, 0, 0, 0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c, d, e, f, g) in nat: a < b < c < d < e < f < g failed (7 shrink steps):
-
-(0, 0, 0, 0, 0, 0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c, d, e, f, g, h) in nat: a < b < c < d < e < f < g < h failed (8 shrink steps):
-
-(0, 0, 0, 0, 0, 0, 0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c, d, e, f, g, h, i) in nat: a < b < c < d < e < f < g < h < i failed (9 shrink steps):
-
-(0, 0, 0, 0, 0, 0, 0, 0, 0)
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck2_expect_test.expected
+++ b/test/core/QCheck2_expect_test.expected
@@ -296,7 +296,7 @@ Test nat < 5001 failed (7 shrink steps):
 
 --- Failure --------------------------------------------------------------------
 
-Test char is never produces 'abcdef' failed (1 shrink steps):
+Test char never produces 'abcdef' failed (1 shrink steps):
 
 'a'
 

--- a/test/core/QCheck2_tests.ml
+++ b/test/core/QCheck2_tests.ml
@@ -315,7 +315,7 @@ module Shrink = struct
       Gen.nat (fun n -> n < 5001)
 
   let char_is_never_abcdef =
-    Test.make ~name:"char is never produces 'abcdef'" ~count:1000 ~print:Print.char
+    Test.make ~name:"char never produces 'abcdef'" ~count:1000 ~print:Print.char
       Gen.char (fun c -> not (List.mem c ['a';'b';'c';'d';'e';'f']))
 
   let strings_are_empty =

--- a/test/core/QCheck2_tests.ml
+++ b/test/core/QCheck2_tests.ml
@@ -1,5 +1,10 @@
 (** QCheck2 tests **)
 
+(* Please add any additional tests to both [QCheck_tests.ml] and [QCheck2_tests.ml].
+   This ensures that both generator approaches continue to work as expected
+   and furthermore allows us to compare their behaviour with
+   [diff -y test/core/QCheck_expect_test.expected test/core/QCheck2_expect_test.expected] *)
+
 (** Module representing a integer tree data structure, used in tests *)
 module IntTree = struct
   type tree = Leaf of int | Node of tree * tree

--- a/test/core/QCheck2_tests.ml
+++ b/test/core/QCheck2_tests.ml
@@ -157,39 +157,6 @@ module Generator = struct
       Gen.(quad small_nat small_nat small_nat small_nat)
       (fun (h,i,j,k) -> (h+i)*(j+k) = h*j + h*k + i*j + i*k)
 
-  let bind_test =
-    Test.make ~name:"bind test for ordered pairs" ~count:1000 ~print:Print.(pair int int)
-      Gen.(small_nat >>= fun j -> int_bound j >>= fun i -> return (i,j))
-      (fun (i,j) -> i<=j)
-
-  let bind_pair_list_length =
-    Test.make ~name:"bind list length" ~count:1000 ~print:Print.(pair int (list int))
-      Gen.(int_bound 1000 >>= fun len ->
-           list_size (return len) (int_bound 10) >>= fun xs -> return (len,xs))
-      (fun (len,xs) -> len = List.length xs)
-
-  let list_test =
-    Test.make ~name:"list has right length" ~count:1000
-      ~print:Print.(list unit)
-      Gen.(list unit) (fun l -> let len = List.length l in 0 <= len && len < 10_000)
-
-  let list_repeat_test =
-    Test.make ~name:"list_repeat has constant length" ~count:1000
-      ~print:Print.(pair int (list unit))
-      Gen.(small_nat >>= fun i -> list_repeat i unit >>= fun l -> return (i,l))
-      (fun (i,l) -> List.length l = i)
-
-  let array_repeat_test =
-    Test.make ~name:"array_repeat has constant length" ~count:1000
-      ~print:Print.(pair int (array unit))
-      Gen.(small_nat >>= fun i -> array_repeat i unit >>= fun l -> return (i,l))
-      (fun (i,l) -> Array.length l = i)
-
-  let passing_tree_rev =
-    Test.make ~name:"tree_rev_is_involutive" ~count:1000
-      IntTree.gen_tree
-      (fun tree -> IntTree.(rev_tree (rev_tree tree)) = tree)
-
   let test_tup2 =
     Test.make ~count:10
       ~name:"forall x in (0, 1): x = (0, 1)"
@@ -244,6 +211,39 @@ module Generator = struct
          (pure 5) (pure 6) (pure 7) (pure 8))
       (fun x -> x = (0, 1, 2, 3, 4, 5, 6, 7, 8))
 
+  let bind_test =
+    Test.make ~name:"bind test for ordered pairs" ~count:1000 ~print:Print.(pair int int)
+      Gen.(small_nat >>= fun j -> int_bound j >>= fun i -> return (i,j))
+      (fun (i,j) -> i<=j)
+
+  let bind_pair_list_length =
+    Test.make ~name:"bind list length" ~count:1000 ~print:Print.(pair int (list int))
+      Gen.(int_bound 1000 >>= fun len ->
+           list_size (return len) (int_bound 10) >>= fun xs -> return (len,xs))
+      (fun (len,xs) -> len = List.length xs)
+
+  let list_test =
+    Test.make ~name:"list has right length" ~count:1000
+      ~print:Print.(list unit)
+      Gen.(list unit) (fun l -> let len = List.length l in 0 <= len && len < 10_000)
+
+  let list_repeat_test =
+    Test.make ~name:"list_repeat has constant length" ~count:1000
+      ~print:Print.(pair int (list unit))
+      Gen.(small_nat >>= fun i -> list_repeat i unit >>= fun l -> return (i,l))
+      (fun (i,l) -> List.length l = i)
+
+  let array_repeat_test =
+    Test.make ~name:"array_repeat has constant length" ~count:1000
+      ~print:Print.(pair int (array unit))
+      Gen.(small_nat >>= fun i -> array_repeat i unit >>= fun l -> return (i,l))
+      (fun (i,l) -> Array.length l = i)
+
+  let passing_tree_rev =
+    Test.make ~name:"tree_rev_is_involutive" ~count:1000
+      IntTree.gen_tree
+      (fun tree -> IntTree.(rev_tree (rev_tree tree)) = tree)
+
   let tests = [
     char_dist_issue_23;
     char_test;
@@ -252,12 +252,6 @@ module Generator = struct
     pair_test;
     triple_test;
     quad_test;
-    bind_test;
-    bind_pair_list_length;
-    list_test;
-    list_repeat_test;
-    array_repeat_test;
-    passing_tree_rev;
     test_tup2;
     test_tup3;
     test_tup4;
@@ -266,6 +260,12 @@ module Generator = struct
     test_tup7;
     test_tup8;
     test_tup9;
+    bind_test;
+    bind_pair_list_length;
+    list_test;
+    list_repeat_test;
+    array_repeat_test;
+    passing_tree_rev;
   ]
 end
 
@@ -410,60 +410,6 @@ module Shrink = struct
     Test.make ~name:"quadruples are ordered reversely" ~print:Print.(quad int int int int)
       Gen.(quad int int int int) (fun (h,i,j,k) -> h >= i && i >= j && j >= k)
 
-  let bind_pair_ordered =
-    Test.make ~name:"bind ordered pairs" ~print:Print.(pair int int)
-      Gen.(pint ~origin:0 >>= fun j -> int_bound j >>= fun i -> return (i,j))
-      (fun (_i,_j) -> false)
-
-  let bind_pair_list_size =
-    Test.make ~name:"bind list_size constant" ~print:Print.(pair int (list int))
-      Gen.(int_bound 1000 >>= fun len ->
-           list_size (return len) (int_bound 1000) >>= fun xs -> return (len,xs))
-      (fun (len,xs) -> let len' = List.length xs in len=len' && len' < 4)
-
-  (* tests from issue #64 *)
-  let print_list xs = print_endline Print.(list int xs)
-
-  let lists_are_empty_issue_64 =
-    Test.make ~name:"lists are empty" ~print:Print.(list int)
-      Gen.(list small_int) (fun xs -> print_list xs; xs = [])
-
-  let list_shorter_10 =
-    Test.make ~name:"lists shorter than 10" ~print:Print.(list int)
-      Gen.(list small_int) (fun xs -> List.length xs < 10)
-
-  let length_printer xs =
-    Printf.sprintf "[...] list length: %i" (List.length xs)
-
-  let size_gen = Gen.(oneof [small_nat; int_bound 750_000])
-
-  let list_shorter_432 =
-    Test.make ~name:"lists shorter than 432" ~print:length_printer
-      Gen.(list_size size_gen small_int)
-      (fun xs -> List.length xs < 432)
-
-  let list_shorter_4332 =
-    Test.make ~name:"lists shorter than 4332" ~print:length_printer
-      Gen.(list_size size_gen small_int)
-      (fun xs -> List.length xs < 4332)
-
-  let list_equal_dupl =
-    Test.make ~name:"lists equal to duplication" ~print:Print.(list int)
-      Gen.(list_size size_gen small_int)
-      (fun xs -> try xs = xs @ xs
-                 with Stack_overflow -> false)
-
-  let list_unique_elems =
-    Test.make ~name:"lists have unique elems" ~print:Print.(list int)
-      Gen.(list small_int)
-      (fun xs -> let ys = List.sort_uniq Int.compare xs in
-                 print_list xs; List.length xs = List.length ys)
-
-  let tree_contains_only_42 =
-    Test.make ~name:"tree contains only 42" ~print:IntTree.print_tree
-      IntTree.gen_tree
-      (fun tree -> IntTree.contains_only_n tree 42)
-
   let test_tup2 =
     Test.make
       ~print:Print.(tup2 int int)
@@ -520,6 +466,60 @@ module Shrink = struct
       Gen.(tup9 small_int small_int small_int small_int small_int small_int small_int small_int small_int)
       (fun (a, b, c, d, e, f, g, h, i) -> a < b && b < c && c < d && d < e && e < f && f < g && g < h && h < i)
 
+  let bind_pair_ordered =
+    Test.make ~name:"bind ordered pairs" ~print:Print.(pair int int)
+      Gen.(pint ~origin:0 >>= fun j -> int_bound j >>= fun i -> return (i,j))
+      (fun (_i,_j) -> false)
+
+  let bind_pair_list_size =
+    Test.make ~name:"bind list_size constant" ~print:Print.(pair int (list int))
+      Gen.(int_bound 1000 >>= fun len ->
+           list_size (return len) (int_bound 1000) >>= fun xs -> return (len,xs))
+      (fun (len,xs) -> let len' = List.length xs in len=len' && len' < 4)
+
+  (* tests from issue #64 *)
+  let print_list xs = print_endline Print.(list int xs)
+
+  let lists_are_empty_issue_64 =
+    Test.make ~name:"lists are empty" ~print:Print.(list int)
+      Gen.(list small_int) (fun xs -> print_list xs; xs = [])
+
+  let list_shorter_10 =
+    Test.make ~name:"lists shorter than 10" ~print:Print.(list int)
+      Gen.(list small_int) (fun xs -> List.length xs < 10)
+
+  let length_printer xs =
+    Printf.sprintf "[...] list length: %i" (List.length xs)
+
+  let size_gen = Gen.(oneof [small_nat; int_bound 750_000])
+
+  let list_shorter_432 =
+    Test.make ~name:"lists shorter than 432" ~print:length_printer
+      Gen.(list_size size_gen small_int)
+      (fun xs -> List.length xs < 432)
+
+  let list_shorter_4332 =
+    Test.make ~name:"lists shorter than 4332" ~print:length_printer
+      Gen.(list_size size_gen small_int)
+      (fun xs -> List.length xs < 4332)
+
+  let list_equal_dupl =
+    Test.make ~name:"lists equal to duplication" ~print:Print.(list int)
+      Gen.(list_size size_gen small_int)
+      (fun xs -> try xs = xs @ xs
+                 with Stack_overflow -> false)
+
+  let list_unique_elems =
+    Test.make ~name:"lists have unique elems" ~print:Print.(list int)
+      Gen.(list small_int)
+      (fun xs -> let ys = List.sort_uniq Int.compare xs in
+                 print_list xs; List.length xs = List.length ys)
+
+  let tree_contains_only_42 =
+    Test.make ~name:"tree contains only 42" ~print:IntTree.print_tree
+      IntTree.gen_tree
+      (fun tree -> IntTree.contains_only_n tree 42)
+
   let tests = [
     (*test_fac_issue59;*)
     big_bound_issue59;
@@ -550,6 +550,14 @@ module Shrink = struct
     quad_same;
     quad_ordered;
     quad_ordered_rev;
+    test_tup2;
+    test_tup3;
+    test_tup4;
+    test_tup5;
+    test_tup6;
+    test_tup7;
+    test_tup8;
+    test_tup9;
     bind_pair_ordered;
     bind_pair_list_size;
     lists_are_empty_issue_64;
@@ -559,14 +567,6 @@ module Shrink = struct
     list_equal_dupl;
     list_unique_elems;
     tree_contains_only_42;
-    test_tup2;
-    test_tup3;
-    test_tup4;
-    test_tup5;
-    test_tup6;
-    test_tup7;
-    test_tup8;
-    test_tup9;
   ]
 end
 

--- a/test/core/QCheck_expect_test.expected
+++ b/test/core/QCheck_expect_test.expected
@@ -231,7 +231,7 @@ Test nat < 5001 failed (6 shrink steps):
 
 --- Failure --------------------------------------------------------------------
 
-Test char is never produces 'abcdef' failed (0 shrink steps):
+Test char never produces 'abcdef' failed (0 shrink steps):
 
 'd'
 

--- a/test/core/QCheck_expect_test.expected
+++ b/test/core/QCheck_expect_test.expected
@@ -411,6 +411,12 @@ Test lists have unique elems failed (7 shrink steps):
 
 --- Failure --------------------------------------------------------------------
 
+Test tree contains only 42 failed (10 shrink steps):
+
+Leaf 0
+
+--- Failure --------------------------------------------------------------------
+
 Test forall (a, b) in nat: a < b failed (13 shrink steps):
 
 (0, 0)
@@ -456,12 +462,6 @@ Test forall (a, b, c, d, e, f, g, h) in nat: a < b < c < d < e < f < g < h faile
 Test forall (a, b, c, d, e, f, g, h, i) in nat: a < b < c < d < e < f < g < h < i failed (42 shrink steps):
 
 (0, 0, 0, 0, 0, 0, 0, 0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test tree contains only 42 failed (10 shrink steps):
-
-Leaf 0
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected
+++ b/test/core/QCheck_expect_test.expected
@@ -363,6 +363,54 @@ Test quadruples are ordered reversely failed (251 shrink steps):
 
 --- Failure --------------------------------------------------------------------
 
+Test forall (a, b) in nat: a < b failed (13 shrink steps):
+
+(0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c) in nat: a < b < c failed (15 shrink steps):
+
+(0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c, d) in nat: a < b < c < d failed (23 shrink steps):
+
+(0, 0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c, d, e) in nat: a < b < c < d < e failed (28 shrink steps):
+
+(0, 0, 0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c, d, e, f) in nat: a < b < c < d < e < f failed (30 shrink steps):
+
+(0, 0, 0, 0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c, d, e, f, g) in nat: a < b < c < d < e < f < g failed (31 shrink steps):
+
+(0, 0, 0, 0, 0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c, d, e, f, g, h) in nat: a < b < c < d < e < f < g < h failed (35 shrink steps):
+
+(0, 0, 0, 0, 0, 0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
+Test forall (a, b, c, d, e, f, g, h, i) in nat: a < b < c < d < e < f < g < h < i failed (42 shrink steps):
+
+(0, 0, 0, 0, 0, 0, 0, 0, 0)
+
+--- Failure --------------------------------------------------------------------
+
 Test bind ordered pairs failed (125 shrink steps):
 
 (0, 0)
@@ -414,54 +462,6 @@ Test lists have unique elems failed (7 shrink steps):
 Test tree contains only 42 failed (10 shrink steps):
 
 Leaf 0
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b) in nat: a < b failed (13 shrink steps):
-
-(0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c) in nat: a < b < c failed (15 shrink steps):
-
-(0, 0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c, d) in nat: a < b < c < d failed (23 shrink steps):
-
-(0, 0, 0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c, d, e) in nat: a < b < c < d < e failed (28 shrink steps):
-
-(0, 0, 0, 0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c, d, e, f) in nat: a < b < c < d < e < f failed (30 shrink steps):
-
-(0, 0, 0, 0, 0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c, d, e, f, g) in nat: a < b < c < d < e < f < g failed (31 shrink steps):
-
-(0, 0, 0, 0, 0, 0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c, d, e, f, g, h) in nat: a < b < c < d < e < f < g < h failed (35 shrink steps):
-
-(0, 0, 0, 0, 0, 0, 0, 0)
-
---- Failure --------------------------------------------------------------------
-
-Test forall (a, b, c, d, e, f, g, h, i) in nat: a < b < c < d < e < f < g < h < i failed (42 shrink steps):
-
-(0, 0, 0, 0, 0, 0, 0, 0, 0)
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_tests.ml
+++ b/test/core/QCheck_tests.ml
@@ -120,16 +120,7 @@ module Overall = struct
   ]
 end
 
-(* positive tests of the various generators
-
-   Note: it is important to disable shrinking for these tests, as the
-   shrinkers will suggest inputs that are coming from the generators
-   themselves -- which we want to test -- so their reduced
-   counter-example are confusing rather than helpful.
-
-   This is achieved by using (Test.make ~print ...), without a ~shrink
-   argument.
-*)
+(* positive tests of the various generators *)
 module Generator = struct
   open QCheck
 

--- a/test/core/QCheck_tests.ml
+++ b/test/core/QCheck_tests.ml
@@ -399,7 +399,7 @@ module Shrink = struct
       (make ~print:Print.int ~shrink:Shrink.int Gen.nat) (fun n -> n < 5001)
 
   let char_is_never_abcdef =
-    Test.make ~name:"char is never produces 'abcdef'" ~count:1000
+    Test.make ~name:"char never produces 'abcdef'" ~count:1000
       char (fun c -> not (List.mem c ['a';'b';'c';'d';'e';'f']))
 
   let strings_are_empty =

--- a/test/core/QCheck_tests.ml
+++ b/test/core/QCheck_tests.ml
@@ -1,5 +1,10 @@
 (** QCheck(1) tests **)
 
+(* Please add any additional tests to both [QCheck_tests.ml] and [QCheck2_tests.ml].
+   This ensures that both generator approaches continue to work as expected
+   and furthermore allows us to compare their behaviour with
+   [diff -y test/core/QCheck_expect_test.expected test/core/QCheck2_expect_test.expected] *)
+
 (** Module representing a tree data structure, used in tests *)
 module IntTree = struct
   open QCheck

--- a/test/core/QCheck_tests.ml
+++ b/test/core/QCheck_tests.ml
@@ -542,6 +542,11 @@ module Shrink = struct
       (fun xs -> let ys = List.sort_uniq Int.compare xs in
                  print_list xs; List.length xs = List.length ys)
 
+  let tree_contains_only_42 =
+    Test.make ~name:"tree contains only 42"
+      IntTree.(make ~print:print_tree ~shrink:shrink_tree gen_tree)
+      (fun tree -> IntTree.contains_only_n tree 42)
+
   let test_tup2 =
     Test.make
       ~name:"forall (a, b) in nat: a < b"
@@ -590,11 +595,6 @@ module Shrink = struct
       (tup9 small_int small_int small_int small_int small_int small_int small_int small_int small_int)
       (fun (a, b, c, d, e, f, g, h, i) -> a < b && b < c && c < d && d < e && e < f && f < g && g < h && h < i)
 
-  let tree_contains_only_42 =
-    Test.make ~name:"tree contains only 42"
-      IntTree.(make ~print:print_tree ~shrink:shrink_tree gen_tree)
-      (fun tree -> IntTree.contains_only_n tree 42)
-
   let tests = [
     (*test_fac_issue59;*)
     big_bound_issue59;
@@ -633,6 +633,7 @@ module Shrink = struct
     list_shorter_4332;
     list_equal_dupl;
     list_unique_elems;
+    tree_contains_only_42;
     test_tup2;
     test_tup3;
     test_tup4;
@@ -641,7 +642,6 @@ module Shrink = struct
     test_tup7;
     test_tup8;
     test_tup9;
-    tree_contains_only_42;
   ]
 end
 

--- a/test/core/QCheck_tests.ml
+++ b/test/core/QCheck_tests.ml
@@ -163,6 +163,60 @@ module Generator = struct
       (quad small_nat small_nat small_nat small_nat)
       (fun (h,i,j,k) -> (h+i)*(j+k) = h*j + h*k + i*j + i*k)
 
+  let test_tup2 =
+    Test.make ~count:10
+      ~name:"forall x in (0, 1): x = (0, 1)"
+      (tup2 (always 0) (always 1))
+      (fun x -> x = (0, 1))
+
+  let test_tup3 =
+    Test.make ~count:10
+      ~name:"forall x in (0, 1, 2): x = (0, 1, 2)"
+      (tup3 (always 0) (always 1) (always 2))
+      (fun x -> x = (0, 1, 2))
+
+  let test_tup4 =
+    Test.make ~count:10
+      ~name:"forall x in (0, 1, 2, 3): x = (0, 1, 2, 3)"
+      (tup4 (always 0) (always 1) (always 2) (always 3))
+      (fun x -> x = (0, 1, 2, 3))
+
+  let test_tup5 =
+    Test.make ~count:10
+      ~name:"forall x in (0, 1, 2, 3, 4): x = (0, 1, 2, 3, 4)"
+      (tup5 (always 0) (always 1) (always 2) (always 3) (always 4))
+      (fun x -> x = (0, 1, 2, 3, 4))
+
+  let test_tup6 =
+    Test.make ~count:10
+      ~name:"forall x in (0, 1, 2, 3, 4, 5): x = (0, 1, 2, 3, 4, 5)"
+      (tup6 (always 0) (always 1) (always 2) (always 3) (always 4) (always 5))
+      (fun x -> x = (0, 1, 2, 3, 4, 5))
+
+  let test_tup7 =
+    Test.make ~count:10
+      ~name:"forall x in (0, 1, 2, 3, 4, 5, 6): x = (0, 1, 2, 3, 4, 5, 6)"
+      (tup7
+         (always 0) (always 1) (always 2) (always 3) (always 4)
+         (always 5) (always 6))
+      (fun x -> x = (0, 1, 2, 3, 4, 5, 6))
+
+  let test_tup8 =
+    Test.make ~count:10
+      ~name:"forall x in (0, 1, 2, 3, 4, 5, 6, 7): x = (0, 1, 2, 3, 4, 5, 6, 7)"
+      (tup8
+         (always 0) (always 1) (always 2) (always 3) (always 4)
+         (always 5) (always 6) (always 7))
+      (fun x -> x = (0, 1, 2, 3, 4, 5, 6, 7))
+
+  let test_tup9 =
+    Test.make ~count:10
+      ~name:"forall x in (0, 1, 2, 3, 4, 5, 6, 7, 8): x = (0, 1, 2, 3, 4, 5, 6, 7, 8)"
+      (tup9
+         (always 0) (always 1) (always 2) (always 3) (always 4)
+         (always 5) (always 6) (always 7) (always 8))
+      (fun x -> x = (0, 1, 2, 3, 4, 5, 6, 7, 8))
+
   let bind_test =
     Test.make ~name:"bind test for ordered pairs" ~count:1000
       (make Gen.(small_nat >>= fun j -> int_bound j >>= fun i -> return (i,j)))
@@ -269,60 +323,6 @@ module Generator = struct
          && Array.for_all (fun k -> 0 < k) arr
          && Array.fold_left (+) 0 arr = n)
 
-  let test_tup2 =
-    Test.make ~count:10
-      ~name:"forall x in (0, 1): x = (0, 1)"
-      (tup2 (always 0) (always 1))
-      (fun x -> x = (0, 1))
-
-  let test_tup3 =
-    Test.make ~count:10
-      ~name:"forall x in (0, 1, 2): x = (0, 1, 2)"
-      (tup3 (always 0) (always 1) (always 2))
-      (fun x -> x = (0, 1, 2))
-
-  let test_tup4 =
-    Test.make ~count:10
-      ~name:"forall x in (0, 1, 2, 3): x = (0, 1, 2, 3)"
-      (tup4 (always 0) (always 1) (always 2) (always 3))
-      (fun x -> x = (0, 1, 2, 3))
-
-  let test_tup5 =
-    Test.make ~count:10
-      ~name:"forall x in (0, 1, 2, 3, 4): x = (0, 1, 2, 3, 4)"
-      (tup5 (always 0) (always 1) (always 2) (always 3) (always 4))
-      (fun x -> x = (0, 1, 2, 3, 4))
-
-  let test_tup6 =
-    Test.make ~count:10
-      ~name:"forall x in (0, 1, 2, 3, 4, 5): x = (0, 1, 2, 3, 4, 5)"
-      (tup6 (always 0) (always 1) (always 2) (always 3) (always 4) (always 5))
-      (fun x -> x = (0, 1, 2, 3, 4, 5))
-
-  let test_tup7 =
-    Test.make ~count:10
-      ~name:"forall x in (0, 1, 2, 3, 4, 5, 6): x = (0, 1, 2, 3, 4, 5, 6)"
-      (tup7
-         (always 0) (always 1) (always 2) (always 3) (always 4)
-         (always 5) (always 6))
-      (fun x -> x = (0, 1, 2, 3, 4, 5, 6))
-
-  let test_tup8 =
-    Test.make ~count:10
-      ~name:"forall x in (0, 1, 2, 3, 4, 5, 6, 7): x = (0, 1, 2, 3, 4, 5, 6, 7)"
-      (tup8
-         (always 0) (always 1) (always 2) (always 3) (always 4)
-         (always 5) (always 6) (always 7))
-      (fun x -> x = (0, 1, 2, 3, 4, 5, 6, 7))
-
-  let test_tup9 =
-    Test.make ~count:10
-      ~name:"forall x in (0, 1, 2, 3, 4, 5, 6, 7, 8): x = (0, 1, 2, 3, 4, 5, 6, 7, 8)"
-      (tup9
-         (always 0) (always 1) (always 2) (always 3) (always 4)
-         (always 5) (always 6) (always 7) (always 8))
-      (fun x -> x = (0, 1, 2, 3, 4, 5, 6, 7, 8))
-
   let tests = [
     char_dist_issue_23;
     char_test;
@@ -331,6 +331,14 @@ module Generator = struct
     pair_test;
     triple_test;
     quad_test;
+    test_tup2;
+    test_tup3;
+    test_tup4;
+    test_tup5;
+    test_tup6;
+    test_tup7;
+    test_tup8;
+    test_tup9;
     bind_test;
     bind_pair_list_length;
     list_test;
@@ -343,14 +351,6 @@ module Generator = struct
     nat_split_n_way;
     nat_split_smaller;
     pos_split;
-    test_tup2;
-    test_tup3;
-    test_tup4;
-    test_tup5;
-    test_tup6;
-    test_tup7;
-    test_tup8;
-    test_tup9;
   ]
 end
 
@@ -488,6 +488,54 @@ module Shrink = struct
     Test.make ~name:"quadruples are ordered reversely"
       (quad int int int int) (fun (h,i,j,k) -> h >= i && i >= j && j >= k)
 
+  let test_tup2 =
+    Test.make
+      ~name:"forall (a, b) in nat: a < b"
+      (tup2 small_int small_int)
+      (fun (a, b) -> a < b)
+
+  let test_tup3 =
+    Test.make
+      ~name:"forall (a, b, c) in nat: a < b < c"
+      (tup3 small_int small_int small_int)
+      (fun (a, b, c) -> a < b && b < c)
+
+  let test_tup4 =
+    Test.make
+      ~name:"forall (a, b, c, d) in nat: a < b < c < d"
+      (tup4 small_int small_int small_int small_int)
+      (fun (a, b, c, d) -> a < b && b < c && c < d)
+
+  let test_tup5 =
+    Test.make
+      ~name:"forall (a, b, c, d, e) in nat: a < b < c < d < e"
+      (tup5 small_int small_int small_int small_int small_int)
+      (fun (a, b, c, d, e) -> a < b && b < c && c < d && d < e)
+
+  let test_tup6 =
+    Test.make
+      ~name:"forall (a, b, c, d, e, f) in nat: a < b < c < d < e < f"
+      (tup6 small_int small_int small_int small_int small_int small_int)
+      (fun (a, b, c, d, e, f) -> a < b && b < c && c < d && d < e && e < f)
+
+  let test_tup7 =
+    Test.make
+      ~name:"forall (a, b, c, d, e, f, g) in nat: a < b < c < d < e < f < g"
+      (tup7 small_int small_int small_int small_int small_int small_int small_int)
+      (fun (a, b, c, d, e, f, g) -> a < b && b < c && c < d && d < e && e < f && f < g)
+
+  let test_tup8 =
+    Test.make
+      ~name:"forall (a, b, c, d, e, f, g, h) in nat: a < b < c < d < e < f < g < h"
+      (tup8 small_int small_int small_int small_int small_int small_int small_int small_int)
+      (fun (a, b, c, d, e, f, g, h) -> a < b && b < c && c < d && d < e && e < f && f < g && g < h)
+
+  let test_tup9 =
+    Test.make
+      ~name:"forall (a, b, c, d, e, f, g, h, i) in nat: a < b < c < d < e < f < g < h < i"
+      (tup9 small_int small_int small_int small_int small_int small_int small_int small_int small_int)
+      (fun (a, b, c, d, e, f, g, h, i) -> a < b && b < c && c < d && d < e && e < f && f < g && g < h && h < i)
+
   let bind_pair_ordered =
     Test.make ~name:"bind ordered pairs"
       (make ~print:Print.(pair int int)
@@ -547,54 +595,6 @@ module Shrink = struct
       IntTree.(make ~print:print_tree ~shrink:shrink_tree gen_tree)
       (fun tree -> IntTree.contains_only_n tree 42)
 
-  let test_tup2 =
-    Test.make
-      ~name:"forall (a, b) in nat: a < b"
-      (tup2 small_int small_int)
-      (fun (a, b) -> a < b)
-
-  let test_tup3 =
-    Test.make
-      ~name:"forall (a, b, c) in nat: a < b < c"
-      (tup3 small_int small_int small_int)
-      (fun (a, b, c) -> a < b && b < c)
-
-  let test_tup4 =
-    Test.make
-      ~name:"forall (a, b, c, d) in nat: a < b < c < d"
-      (tup4 small_int small_int small_int small_int)
-      (fun (a, b, c, d) -> a < b && b < c && c < d)
-
-  let test_tup5 =
-    Test.make
-      ~name:"forall (a, b, c, d, e) in nat: a < b < c < d < e"
-      (tup5 small_int small_int small_int small_int small_int)
-      (fun (a, b, c, d, e) -> a < b && b < c && c < d && d < e)
-
-  let test_tup6 =
-    Test.make
-      ~name:"forall (a, b, c, d, e, f) in nat: a < b < c < d < e < f"
-      (tup6 small_int small_int small_int small_int small_int small_int)
-      (fun (a, b, c, d, e, f) -> a < b && b < c && c < d && d < e && e < f)
-
-  let test_tup7 =
-    Test.make
-      ~name:"forall (a, b, c, d, e, f, g) in nat: a < b < c < d < e < f < g"
-      (tup7 small_int small_int small_int small_int small_int small_int small_int)
-      (fun (a, b, c, d, e, f, g) -> a < b && b < c && c < d && d < e && e < f && f < g)
-
-  let test_tup8 =
-    Test.make
-      ~name:"forall (a, b, c, d, e, f, g, h) in nat: a < b < c < d < e < f < g < h"
-      (tup8 small_int small_int small_int small_int small_int small_int small_int small_int)
-      (fun (a, b, c, d, e, f, g, h) -> a < b && b < c && c < d && d < e && e < f && f < g && g < h)
-
-  let test_tup9 =
-    Test.make
-      ~name:"forall (a, b, c, d, e, f, g, h, i) in nat: a < b < c < d < e < f < g < h < i"
-      (tup9 small_int small_int small_int small_int small_int small_int small_int small_int small_int)
-      (fun (a, b, c, d, e, f, g, h, i) -> a < b && b < c && c < d && d < e && e < f && f < g && g < h && h < i)
-
   let tests = [
     (*test_fac_issue59;*)
     big_bound_issue59;
@@ -625,6 +625,14 @@ module Shrink = struct
     quad_same;
     quad_ordered;
     quad_ordered_rev;
+    test_tup2;
+    test_tup3;
+    test_tup4;
+    test_tup5;
+    test_tup6;
+    test_tup7;
+    test_tup8;
+    test_tup9;
     bind_pair_ordered;
     bind_pair_list_size;
     lists_are_empty_issue_64;
@@ -634,14 +642,6 @@ module Shrink = struct
     list_equal_dupl;
     list_unique_elems;
     tree_contains_only_42;
-    test_tup2;
-    test_tup3;
-    test_tup4;
-    test_tup5;
-    test_tup6;
-    test_tup7;
-    test_tup8;
-    test_tup9;
   ]
 end
 


### PR DESCRIPTION
This is a purely administrative PR that simply reorders a bunch of QCheck/QCheck2 tests to keep them and their order in sync.

It also removes a confusing comment about using `Test.make` without a `~shrink`-parameter:
`Test.make` does not accept a `~shrink` parameter.

Finally it corrects a typo in a test name.