### PR TITLE
use Float.equal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.19
 
+- use `Float.equal` for comparing `float`s in the `Observable` module underlying function generators.
+
 - add optional `debug_shrink` parameters in alcotest interface and
   expose default `debug_shrinking_choices` in test runners
 

--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -955,7 +955,7 @@ module Observable = struct
     let int : int t = (=)
     let string : string t = (=)
     let bool : bool t = (=)
-    let float : float t = (=)
+    let float = Float.equal
     let unit () () = true
     let char : char t = (=)
 

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -976,7 +976,7 @@ module Observable = struct
 
     let bool : bool t = (=)
 
-    let float : float t = (=)
+    let float = Float.equal
 
     let unit () () = true
 


### PR DESCRIPTION
Polymorphic equality is ill-defined regarding `nan`. This PR proposes to use `Float.equal` instead. The rational being that a test failling because `nan <> nan` is not very informative w.r.t the tested program.
