### PR TITLE
parametirize string shrinker with a char shrinker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changes
 
+- add an optional argument with conservative default to `Shrink.string`
+- fix shrinkers in `QCheck.{printable_string,printable_string_of_size,small_printable_string,numeral_string,numeral_string_of_size}` [#257](https://github.com/c-cube/qcheck/issues/257)
+
 ## 0.19.1
 
 - fix: allow `~count` in `Test.make` to be 0

--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -770,9 +770,9 @@ module Shrink = struct
     | None -> ()
     | Some shrink -> list_elems shrink l yield
 
-  let string s yield =
+  let string ?(shrink = char) s yield =
     let buf = Buffer.create 42 in
-    list ~shrink:char
+    list ~shrink
       (string_fold_right (fun c acc -> c::acc) s [])
       (fun cs ->
          List.iter (fun c -> Buffer.add_char buf c) cs;
@@ -1120,12 +1120,25 @@ let string = string_gen Gen.char
 let string_of_size size = string_gen_of_size size Gen.char
 let small_string = string_gen_of_size Gen.small_nat Gen.char
 
-let printable_string = string_gen Gen.printable
-let printable_string_of_size size = string_gen_of_size size Gen.printable
-let small_printable_string = string_gen_of_size Gen.small_nat Gen.printable
+let printable_string =
+  make ~shrink:(Shrink.string ~shrink:Shrink.char_printable) ~small:String.length
+    ~print:(sprintf "%S") (Gen.string ~gen:Gen.printable)
 
-let numeral_string = string_gen Gen.numeral
-let numeral_string_of_size size = string_gen_of_size size Gen.numeral
+let printable_string_of_size size =
+  make ~shrink:(Shrink.string ~shrink:Shrink.char_printable) ~small:String.length
+    ~print:(sprintf "%S") (Gen.string_size ~gen:Gen.printable size)
+
+let small_printable_string =
+  make ~shrink:(Shrink.string ~shrink:Shrink.char_printable) ~small:String.length
+    ~print:(sprintf "%S") (Gen.string_size ~gen:Gen.printable Gen.small_nat)
+
+let numeral_string =
+  make ~shrink:(Shrink.string ~shrink:Shrink.char_numeral) ~small:String.length
+    ~print:(sprintf "%S") (Gen.string ~gen:Gen.numeral)
+
+let numeral_string_of_size size =
+  make ~shrink:(Shrink.string ~shrink:Shrink.char_numeral) ~small:String.length
+    ~print:(sprintf "%S") (Gen.string_size ~gen:Gen.numeral size)
 
 let list_sum_ f l = List.fold_left (fun acc x-> f x+acc) 0 l
 

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -709,7 +709,7 @@ module Shrink : sig
 
   val option : 'a t -> 'a option t
 
-  val string : string t
+  val string : ?shrink:(char t) -> string t
 
   val filter : ('a -> bool) -> 'a t -> 'a t
   (** [filter f shrink] shrinks values the same as [shrink], but


### PR DESCRIPTION
This PR is an attempt to fix #257.

It does so by:

- adding an optional argument to `Shrink.string` for character shrinking, with a conservative default
- fix character shrinkers in `QCheck.{printable_string,printable_string_of_size,small_printable_string,numeral_string,numeral_string_of_size}` so that they have the expected behaviour.

For now, we don't expose a `string arbitrary` that takes a shrinker as argument. Albeit it would be nice, there is the question of how to do it. I see three possibilities:

1. add an optional argument to `QCheck.string_gen` and `QCheck.string_gen_of_size`
2. add a non-optional argument to `QCheck.string_gen` and `QCheck.string_gen_of_size`
3. add two functions: `QCheck.string_gen_shrink` and `QCheck.string_gen_shrink_of_size`

