### PR TITLE
Add QCHECK_MSG_INTERVAL environment variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - fix shrinkers in `QCheck.{printable_string,printable_string_of_size,small_printable_string,numeral_string,numeral_string_of_size}` [#257](https://github.com/c-cube/qcheck/issues/257)
 - add `QCheck2.Gen.set_shrink` to modify the generator's shrinker
 - add `QCheck2.Gen.no_shrink` to build a generator with no shrinking
+- add an environment variable `QCHECK_MSG_INTERVAL` to control `QCheck_base_runner.time_between_msg`
 
 ## 0.19.1
 

--- a/src/runner/QCheck_base_runner.ml
+++ b/src/runner/QCheck_base_runner.ml
@@ -60,7 +60,14 @@ let set_seed_ ~colors s =
 (* time of last printed message. Useful for rate limiting in verbose mode *)
 let last_msg = ref 0.
 
-let time_between_msg = ref 0.1
+let time_between_msg =
+  let env_var = "QCHECK_MSG_INTERVAL" in
+  let default_interval = 0.1 in
+  let interval = match Sys.getenv_opt env_var with
+    | None -> default_interval
+    | Some f -> float_of_string f in
+  if interval < 0. then invalid_arg (env_var ^ " must be >= 0 but value is " ^ string_of_float interval);
+  ref interval
 
 let get_time_between_msg () = !time_between_msg
 

--- a/src/runner/QCheck_base_runner.ml
+++ b/src/runner/QCheck_base_runner.ml
@@ -65,7 +65,10 @@ let time_between_msg =
   let default_interval = 0.1 in
   let interval = match Sys.getenv_opt env_var with
     | None -> default_interval
-    | Some f -> float_of_string f in
+    | Some f ->
+      match float_of_string_opt f with
+      | None -> invalid_arg (env_var ^ " must be a float")
+      | Some i -> i in
   if interval < 0. then invalid_arg (env_var ^ " must be >= 0 but value is " ^ string_of_float interval);
   ref interval
 


### PR DESCRIPTION
This PR adds an environment variable `QCHECK_MSG_INTERVAL` to control `QCheck_base_runner.time_between_msg`.

This feature is useful in a CI context, where updates are printed on consecutive lines and we want to avoid overflowing the CI log files with too many output lines.
