### PR TITLE
Fix "unknown option" error message from runner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 0.20
 
+- fix unknown option error message referring to `qtest`
 - add an optional argument with conservative default to `Shrink.string`
 - fix shrinkers in `QCheck.{printable_string,printable_string_of_size,small_printable_string,numeral_string,numeral_string_of_size}` [#257](https://github.com/c-cube/qcheck/issues/257)
 - add `QCheck2.Gen.set_shrink` to modify the generator's shrinker

--- a/src/runner/QCheck_base_runner.ml
+++ b/src/runner/QCheck_base_runner.ml
@@ -190,7 +190,7 @@ module Raw = struct
           ; "--debug-shrink-list", Arg.String set_debug_shrink_list, " filter test to debug shrinking on"
           ]
       ) in
-    Arg.parse_argv argv options (fun _ ->()) "run qtest suite";
+    Arg.parse_argv argv options (fun _ ->()) "run QCheck test suite";
     let cli_rand = setup_random_state_ ~colors:!colors () in
     { cli_verbose=verbose(); cli_long_tests=long_tests(); cli_rand;
       cli_print_list= !print_list; cli_slow_test= !slow;


### PR DESCRIPTION
While switching from `dune exec path/some.exe -- -v -s 123` to `_build/default/path/some.exe` I mistakingly passed `--` which is not a valid QCheck option and was surprised by this error message:
```
_build/default/path/some.exe: unknown option '--'.
run qtest suite
  -v                   
  --verbose            enable verbose tests
  --colors             colored output
[...]
```

This PR therefore changes the second line to
```
run QCheck test suite
```