### PR TITLE
Fix is_rec_typ deriver bug(s)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
   `Test.check_exn` honor test polarity by raising
   `Test_unexpected_success` when a negative test (expected to have a
   counter example), unexpectedly succeeds.
+- fix issue with `ppx_deriving_qcheck` deriving a generator with unbound
+  `gen` for recursive types [#269](https://github.com/c-cube/qcheck/issues/269)
+  and a related issue when deriving a generator for a record type
 - ...
 
 ## 0.20

--- a/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
+++ b/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
@@ -111,8 +111,9 @@ let rec longident_to_str = function
       Printf.sprintf "%s %s" (longident_to_str lg1) (longident_to_str lg2)
 
 let rec is_rec_typ env = function
-  | { ptyp_desc = Ptyp_constr ({ txt = x; _ }, _); _ } ->
-     List.exists (fun typ_name -> longident_to_str x = typ_name) env.Env.curr_types
+  | { ptyp_desc = Ptyp_constr ({ txt = x; _ }, args); _ } ->
+     List.exists (fun typ_name -> longident_to_str x = typ_name) env.Env.curr_types ||
+     List.exists (is_rec_typ env) args
   | { ptyp_desc = Ptyp_tuple xs; _ } -> List.exists (is_rec_typ env) xs
   | { ptyp_desc = Ptyp_variant (rws, _, _); _ } ->
      List.exists (is_rec_row_field env) rws

--- a/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
+++ b/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
@@ -129,7 +129,7 @@ and is_rec_row_field env rw =
 let is_rec_constr_decl env cd =
   match cd.pcd_args with
   | Pcstr_tuple cts -> List.exists (is_rec_typ env) cts
-  | _ -> false
+  | Pcstr_record ldcls -> List.exists (fun ldcl -> is_rec_typ env ldcl.pld_type) ldcls
 
 (** [is_rec_type_decl env typ] looks for elements of [env.curr_types]
     recursively in [typ]. *)


### PR DESCRIPTION
This is an attempt at fixing #269.
With the fix in 3c1f147 we are able to derive a straight-forward, type-correct generator for `type t = Foo of t list` (yay!)
```ocaml
let rec gen_sized n =
  QCheck.Gen.map (fun gen0 -> Foo gen0) (QCheck.Gen.list (gen_sized (n / 2)));;
let gen = QCheck.Gen.sized gen_sized
```
which blows the stack (less yay):
```
# Gen.generate1 gen;;
Stack overflow during evaluation (looping recursion?).
```

I think this is to be expected from the current simple, but predictable approach.
It could potentially be improved if we incorporate passing sizing explicitly to the derived `list` generator and thus try to reach a base-case that way.


While fixing this I noticed there was also a problem with record declarations in `is_rec_constr_decl`.
With the fix in daa357e for that, one can derive a functioning generator for a type like `type t = Foo | Bar of { baz : t }`:
```
# Gen.generate1 gen;;
- : t = Bar {baz = Foo}
# Gen.generate1 gen;;
- : t = Foo
```

Overall, this PR should leave the deriver in a slightly better shape than before.
I don't claim it to be bugfree on all language cases though - I think there are still `core_type` cases in `ast.ml` that we may not be handling correctly, e.g., for type constraints.