### PR TITLE
Update GitHub actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,10 +2,10 @@ name: build
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
     branches:
-      - master
+      - main
 jobs:
   run:
     name: Build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,11 @@ jobs:
         ocaml-compiler:
           - 4.08.x
           - 4.12.x
-          - ocaml-base-compiler.5.0.0~beta1
+          - 4.14.x
+          - ocaml-base-compiler.5.0.0
         exclude:
           - os: windows-latest
-            ocaml-compiler: ocaml-base-compiler.5.0.0~beta1
+            ocaml-compiler: ocaml-base-compiler.5.0.0
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2

--- a/example/alcotest/dune
+++ b/example/alcotest/dune
@@ -8,6 +8,12 @@ let suffix =
 
 let dune = Printf.sprintf {|
 
+(env
+ (_
+  (env-vars
+   ; Don't run tests as if Alcotest was run in CI
+   (CI false))))
+
 (executable
   (name QCheck_alcotest_test)
   (libraries qcheck-core qcheck-alcotest alcotest))


### PR DESCRIPTION
Opening #274 I realized the CI was triggered, because of our change from `master` to `main`.
This little PR updates the workflow accordingly, and also adjusts it to test 4.14 and the actual 5.0.0 release.
