### PR TITLE
Reduce ppx_deriving_qcheck's qcheck dependency #273

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## NEXT RELEASE
 
-- ...
+- fix #273 by lowering `ppx_deriving_qcheck`'s `qcheck` dependency to `qcheck-core`
 
 ## 0.21.1
 

--- a/ppx_deriving_qcheck.opam
+++ b/ppx_deriving_qcheck.opam
@@ -10,7 +10,7 @@ author: [ "the qcheck contributors" ]
 depends: [
   "dune" {>= "2.8.0"}
   "ocaml" {>= "4.08.0"}
-  "qcheck" {>= "0.19"}
+  "qcheck-core" {>= "0.19"}
   "ppxlib" {>= "0.22.0"}
   "ppx_deriving" {>= "5.2.1"}
   "odoc" {with-doc}

--- a/test/ppx_deriving_qcheck/deriver/qcheck2/dune
+++ b/test/ppx_deriving_qcheck/deriver/qcheck2/dune
@@ -8,5 +8,5 @@
    test_tuple
    test_variants
    test_record)
- (libraries qcheck-alcotest ppxlib ppx_deriving_qcheck qcheck)
+ (libraries qcheck-alcotest ppxlib ppx_deriving_qcheck qcheck-core)
  (preprocess (pps ppxlib.metaquot ppx_deriving_qcheck)))


### PR DESCRIPTION
This PR fixes #273 by lowering `ppx_deriving_qcheck`s `qcheck` dependency to `qcheck-core`