### PR TITLE
Fix asciidoc error

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -406,10 +406,11 @@ describe("qcheck-rely", ({test}) => {
 
 A ppx_deriver is provided to derive QCheck generators from a type declaration.
 
-```ocaml
+[source,OCaml]
+----
 type tree = Leaf of int | Node of tree * tree
 [@@deriving qcheck]
-```
+----
 
 See the according https://github.com/c-cube/qcheck/tree/master/src/ppx_deriving_qcheck/[README]
 for more information and examples.


### PR DESCRIPTION
Fixes this error with asciidoc 10.2.0 (and fixes incorrect output as well):
```
$ asciidoc README.adoc 
asciidoc: ERROR: README.adoc: line 411: illegal style name: @@deriving qcheck
```
