### PR TITLE
Remove the unnecessary dependency on `bytes`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## NEXT RELEASE
 
-- ...
+- Drop the dependency on `base-bytes` as it is provided in all supported
+  versions of the OCaml compiler
 
 ## 0.21.2
 

--- a/qcheck-alcotest.opam
+++ b/qcheck-alcotest.opam
@@ -19,7 +19,6 @@ build: [
 ]
 depends: [
   "dune" { >= "2.8.0" }
-  "base-bytes"
   "base-unix"
   "qcheck-core" { = version }
   "alcotest" {>= "0.8.1"}

--- a/qcheck-core.opam
+++ b/qcheck-core.opam
@@ -18,7 +18,6 @@ build: [
 ]
 depends: [
   "dune" { >= "2.8.0" }
-  "base-bytes"
   "base-unix"
   "alcotest" {with-test}
   "odoc" {with-doc}

--- a/qcheck-ounit.opam
+++ b/qcheck-ounit.opam
@@ -18,7 +18,6 @@ build: [
 ]
 depends: [
   "dune" { >= "2.8.0" }
-  "base-bytes"
   "base-unix"
   "qcheck-core" { = version }
   "ounit2"

--- a/qcheck.opam
+++ b/qcheck.opam
@@ -18,7 +18,6 @@ build: [
 ]
 depends: [
   "dune" { >= "2.8.0" }
-  "base-bytes"
   "base-unix"
   "qcheck-core" { = version }
   "qcheck-ounit" { = version }

--- a/src/alcotest/dune
+++ b/src/alcotest/dune
@@ -3,6 +3,6 @@
   (name qcheck_alcotest)
   (public_name qcheck-alcotest)
   (wrapped false)
-  (libraries unix bytes qcheck-core qcheck-core.runner alcotest)
+  (libraries unix qcheck-core qcheck-core.runner alcotest)
   (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -safe-string)
   )

--- a/src/core/dune
+++ b/src/core/dune
@@ -3,6 +3,6 @@
   (name qcheck_core)
   (public_name qcheck-core)
   (wrapped false)
-  (libraries unix bytes)
+  (libraries unix)
   (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -safe-string)
   )

--- a/src/ounit/dune
+++ b/src/ounit/dune
@@ -3,6 +3,6 @@
   (name qcheck_ounit)
   (public_name qcheck-ounit)
   (wrapped false)
-  (libraries unix bytes qcheck-core qcheck-core.runner ounit2)
+  (libraries unix qcheck-core qcheck-core.runner ounit2)
   (flags :standard -w +a-4-42-44-48-50-58-32-60@8 -safe-string)
   )


### PR DESCRIPTION
If I understand correctly, the `bytes` dependency is really only useful to support older versions of OCaml (before 4.02), but QCheck requires at least 4.08 anyway.
So this PR proposes to drop that dependency altogether.

To give this a bit more context, this PR comes from wanting to run some tests that use QCheck core in a CI setup where Opam is not an option (yet). So this is working by vendoring QCheck and relying on dune’s modularity. For some reason, dune resolves correctly the `unix` library required in `src/core/dune` but not `bytes`. With this PR, the dependencies of that CI setup drop to only OCaml and dune.