### PR TITLE
Add sig expander to qcheck2

### DIFF
--- a/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
+++ b/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
@@ -634,6 +634,27 @@ let gen_expander_qcheck = Deriving.Generator.V2.make_noarg create_arbs
 
 let gen_expander_qcheck2 = Deriving.Generator.V2.make_noarg (create_gens `QCheck2)
 
-let _ = Deriving.add "qcheck" ~str_type_decl:gen_expander_qcheck
+let gen_sig_expander_qcheck2 =
+  Deriving.Generator.V2.make_noarg
+    (fun ~ctxt  (_rec_flag, tds) ->
+      let loc = Expansion_context.Deriver.derived_item_loc ctxt in
+      let (module A) = Ast_builder.make loc in
+      tds |> List.map (fun td ->
+        let type_name = td.ptype_name.txt in
+        A.psig_value
+          (A.value_description
+            ~name:(A.Located.mk (name type_name))
+            ~type_:(A.ptyp_constr (A.Located.mk (Ldot (Ldot (Lident "QCheck2", "Gen"), "t")))
+                                    [ A.ptyp_constr (A.Located.mk (Lident type_name)) [] ])
+            ~prim:[])))
 
-let _ = Deriving.add "qcheck2" ~str_type_decl:gen_expander_qcheck2
+let _ =
+  Deriving.add
+    "qcheck"
+    ~str_type_decl:gen_expander_qcheck
+
+let _ =
+  Deriving.add
+    "qcheck2"
+    ~str_type_decl:gen_expander_qcheck2
+    ~sig_type_decl:gen_sig_expander_qcheck2

--- a/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
+++ b/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
@@ -636,7 +636,7 @@ let gen_expander_qcheck2 = Deriving.Generator.V2.make_noarg (create_gens `QCheck
 
 let gen_sig_expander_qcheck2 =
   Deriving.Generator.V2.make_noarg
-    (fun ~ctxt  (_rec_flag, tds) ->
+    (fun ~ctxt (_rec_flag, tds) ->
       let loc = Expansion_context.Deriver.derived_item_loc ctxt in
       let (module A) = Ast_builder.make loc in
       tds |> List.map (fun td ->

--- a/test/ppx_deriving_qcheck/deriver/qcheck2/dune
+++ b/test/ppx_deriving_qcheck/deriver/qcheck2/dune
@@ -8,6 +8,6 @@
    test_tuple
    test_variants
    test_record
-   test_sig)
+   test_signatures)
  (libraries qcheck-alcotest ppxlib ppx_deriving_qcheck qcheck-core)
  (preprocess (pps ppxlib.metaquot ppx_deriving_qcheck)))

--- a/test/ppx_deriving_qcheck/deriver/qcheck2/dune
+++ b/test/ppx_deriving_qcheck/deriver/qcheck2/dune
@@ -7,6 +7,7 @@
    test_recursive
    test_tuple
    test_variants
-   test_record)
+   test_record
+   test_sig)
  (libraries qcheck-alcotest ppxlib ppx_deriving_qcheck qcheck-core)
  (preprocess (pps ppxlib.metaquot ppx_deriving_qcheck)))

--- a/test/ppx_deriving_qcheck/deriver/qcheck2/test_sig.ml
+++ b/test/ppx_deriving_qcheck/deriver/qcheck2/test_sig.ml
@@ -1,0 +1,42 @@
+open QCheck2
+open Helpers
+
+(* Here we check that deriving qcheck2 works in signature, and cover the cases
+   where the type is named "t" and when it is not. *)
+
+module T : sig
+  type t = int [@@deriving_inline qcheck2]
+    include sig
+      [@@@ocaml.warning "-32"]
+      val gen : t QCheck2.Gen.t 
+    end
+    [@@ocaml.doc "@inline"]
+  [@@@deriving.end]
+
+  type string' = string [@@deriving_inline qcheck2]
+    include sig
+      [@@@ocaml.warning "-32"]
+      val gen_string' : string' QCheck2.Gen.t 
+    end
+    [@@ocaml.doc "@inline"]
+  [@@@deriving.end]
+end = struct
+  type t = int [@@deriving qcheck2]
+
+  type string' = string [@@deriving qcheck2]
+end
+
+let test_int () =
+  test_compare ~msg:"Gen.int <=> deriving int" ~eq:Alcotest.int Gen.int T.gen
+
+let test_string () =
+  test_compare ~msg:"Gen.string <=> deriving string" ~eq:Alcotest.string Gen.string T.gen_string'
+
+(** {2. Execute tests} *)
+
+let () = Alcotest.run "Test_Primitives"
+           [("Primitives",
+             Alcotest.[
+                 test_case "test_int" `Quick test_int;
+                 test_case "test_unit" `Quick test_string;
+           ])]

--- a/test/ppx_deriving_qcheck/deriver/qcheck2/test_signatures.ml
+++ b/test/ppx_deriving_qcheck/deriver/qcheck2/test_signatures.ml
@@ -27,16 +27,16 @@ end = struct
 end
 
 let test_int () =
-  test_compare ~msg:"Gen.int <=> deriving int" ~eq:Alcotest.int Gen.int T.gen
+  test_compare ~msg:"Gen.int <=> deriving int exported by signature" ~eq:Alcotest.int Gen.int T.gen
 
 let test_string () =
-  test_compare ~msg:"Gen.string <=> deriving string" ~eq:Alcotest.string Gen.string T.gen_string'
+  test_compare ~msg:"Gen.string <=> deriving string exported by signature" ~eq:Alcotest.string Gen.string T.gen_string'
 
 (** {2. Execute tests} *)
 
-let () = Alcotest.run "Test_Primitives"
-           [("Primitives",
+let () = Alcotest.run "Test_Signatures"
+           [("Signatures",
              Alcotest.[
-                 test_case "test_int" `Quick test_int;
-                 test_case "test_unit" `Quick test_string;
+                 test_case "test_int (sig)" `Quick test_int;
+                 test_case "test_string (sig)" `Quick test_string;
            ])]

--- a/test/ppx_deriving_qcheck/deriver/qcheck2/test_signatures.ml
+++ b/test/ppx_deriving_qcheck/deriver/qcheck2/test_signatures.ml
@@ -5,21 +5,9 @@ open Helpers
    where the type is named "t" and when it is not. *)
 
 module T : sig
-  type t = int [@@deriving_inline qcheck2]
-    include sig
-      [@@@ocaml.warning "-32"]
-      val gen : t QCheck2.Gen.t 
-    end
-    [@@ocaml.doc "@inline"]
-  [@@@deriving.end]
+  type t = int [@@deriving qcheck2]
 
-  type string' = string [@@deriving_inline qcheck2]
-    include sig
-      [@@@ocaml.warning "-32"]
-      val gen_string' : string' QCheck2.Gen.t 
-    end
-    [@@ocaml.doc "@inline"]
-  [@@@deriving.end]
+  type string' = string [@@deriving qcheck2]
 end = struct
   type t = int [@@deriving qcheck2]
 


### PR DESCRIPTION
This PR adds support for the `[@@deriving qcheck2]` construct in signatures (such as in `*.mli` files).

For a motivating example, see [here](https://github.com/mransan/ocaml-protoc/pull/233).

Thank you!