### PR TITLE
Remove QCheck2.TestResult.get_instances to address memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## NEXT RELEASE
 
-- ...
+- Remove `QCheck2.TestResult.get_instances` as retaining previous test inputs
+  cause memory leaks
 
 ## 0.21.3
 

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -1354,9 +1354,6 @@ module TestResult = struct
     collect_tbl: (string, int) Hashtbl.t lazy_t;
     stats_tbl: ('a stat * (int, int) Hashtbl.t) list;
     mutable warnings: string list;
-    mutable instances: 'a list;
-    (** List of instances used for this test, in no particular order.
-        @since 0.9 *)
   }
 
   let get_state {state; _} = state
@@ -1390,8 +1387,6 @@ module TestResult = struct
   let get_warnings r = r.warnings
 
   let warnings = get_warnings
-
-  let get_instances r = r.instances
 
   let is_success r = match r.state with
     | Success -> true
@@ -1763,7 +1758,6 @@ module Test = struct
   and check_state_input state input_tree =
     let Tree.Tree (input, _) = input_tree in
     state.handler state.test.name state.test (Collecting input);
-    state.res.R.instances <- input :: state.res.R.instances;
     collect state input;
     update_stats state input;
     let res =
@@ -1835,7 +1829,7 @@ module Test = struct
       res = {R.
               state=R.Success; count=0; count_gen=0;
               collect_tbl=lazy (Hashtbl.create 10);
-              instances=[]; warnings=[];
+              warnings=[];
               stats_tbl= List.map (fun stat -> stat, Hashtbl.create 10) cell.stats;
             };
     } in

--- a/src/core/QCheck2.mli
+++ b/src/core/QCheck2.mli
@@ -1610,10 +1610,6 @@ module TestResult : sig
   (** [get_warnings t] returns the list of warnings emitted during the test.
       @since 0.18 *)
 
-  val get_instances : 'a t -> 'a list
-  (** [get_instances t] returns the generated instances, with no guarantee on the order.
-      @since 0.18 *)
-
   val is_success : _ t -> bool
   (** Returns true iff the state is [Success]
       @since 0.9 *)


### PR DESCRIPTION
`QCheck.TestResult.t.instances` was originally added in dc53caf to address #51.
With the addition of `QCheck2` it was moved there, `QCheck.TestResult.t` was made abstract, and instead
```ocaml
  val QCheck2.TestResult.get_instances : 'a QCheck2.TestResult.t -> 'a list
```
was exposed in the 0.18 interface.

Now https://sherlocode.com/?q=get_instances reveals that noone uses the binding, however #287 reveals that keeping all test inputs causes memory leaks
- that increase with the test count
- that accumulate further as a test list grows.

This PR therefore proposes to remove the list of instances from `TestResult`.

With the PR, on the test case from @esope QCheck2 (and QCheck) regains constant memory usage across increasing test counts - a nice property IMO (beware slight variation below due to different seeds):
```
$ /usr/bin/time --format="max memory: %M kB" _build/default/test_esope.exe 10000
random seed: 404829644
================================================================================
success (ran 1 tests)
max memory: 12628 kB
$ /usr/bin/time --format="max memory: %M kB" _build/default/test_esope.exe 20000
random seed: 234774561
================================================================================
success (ran 1 tests)
max memory: 12500 kB
$ /usr/bin/time --format="max memory: %M kB" _build/default/test_esope.exe 30000
random seed: 263321469
================================================================================
success (ran 1 tests)
max memory: 12628 kB
```
In addition, 12.6MB also seems more reasonable compared to the 300MB, 583MB, 881MB the above use to take!
I suspect performance will improve a bit, due to the decreased GC stress.


For the 2 cases reported by @Robotechnic the situation improves nicely too:
```
$ /usr/bin/time --format="max memory: %M kB" _build/default/robotechnic_list.exe
random seed: 243559907
================================================================================
success (ran 3 tests)
max memory: 64120 kB
$ /usr/bin/time --format="max memory: %M kB" _build/default/robotechnic_sep.exe
random seed: 490585175
================================================================================
success (ran 1 tests)
================================================================================
success (ran 1 tests)
================================================================================
success (ran 1 tests)
max memory: 64928 kB
```

To recap, in a list of 3 tests this uses ~64MB down from ~1151MB
whereas 3 separate runs uses ~65 MB down from ~438MB (again ignoring different seeds)

Because of the way we process tests:
- run and print pass/fail as they execute
- secondly print counterexamples and statistics afterwards

we cannot realistically obtain constant memory usage as test lists grow.

However, as the above numbers show, this seems much more acceptable in the light of the overall memory reduction this PR offers.

----

Edit - Addition:
I believe this will make an even bigger difference for QCheck2 test than for QCheck ones, as the former's generator produces larger lazy shrink trees. 