### PR TITLE
Run macOS runners Intel hardware as 4.08.1 does not support M1/ARM64

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-latest
+          - macos-13
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:


### PR DESCRIPTION
`macos-latest` now refers to an M1/ARM64:
https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
which ocaml.4.08 does not support.

To restore a running CI, this PR thus switches it to the Intel-running macos-13.
(Testing on ARM64 would be nice addition too, but we can address that separately)