### PR TITLE
Add alcotest lower bound for test-dependency

### DIFF
--- a/qcheck-core.opam
+++ b/qcheck-core.opam
@@ -19,7 +19,7 @@ build: [
 depends: [
   "dune" { >= "2.8.0" }
   "base-unix"
-  "alcotest" {with-test}
+  "alcotest" {with-test & >= "1.2.0"}
   "odoc" {with-doc}
   "ocaml" {>= "4.08.0"}
 ]


### PR DESCRIPTION
This upstreams a `qcheck-core` lower bound fixed in opam-repo in https://github.com/ocaml/opam-repository/pull/26169

`test/core/QCheck2_unit_tests.ml` uses `Alcotest.check'` which [was added in 1.2.0](https://github.com/mirage/alcotest/blob/main/CHANGES.md#120-2020-07-13)