### PR TITLE
Make QCheck2.state.res immutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Remove `QCheck2.TestResult.get_instances` as retaining previous test inputs
   cause memory leaks
+- Make `QCheck2.state.res` immutable, silencing a compilation warning
 
 ## 0.21.3
 

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -1562,7 +1562,7 @@ module Test = struct
     step: 'a step;
     handler : 'a handler;
     rand: RS.t;
-    mutable res: 'a TestResult.t;
+    res: 'a TestResult.t;
     mutable cur_count: int;  (** number of iterations remaining to do *)
     mutable cur_max_gen: int; (** maximum number of generations allowed *)
     mutable cur_max_fail: int; (** maximum number of counter-examples allowed *)


### PR DESCRIPTION
QCheck2 fails with compile time warnings:
```ocaml
File "src/core/QCheck2.ml", line 1570, characters 4-33:
1570 |     mutable res: 'a TestResult.t;
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Warning 69 [unused-field]: mutable record field res is never mutated.
```

I think this was just an oversight with the refactoring in connection with QCheck2.
The PR removes the warning and the test suite still passes.