### PR TITLE
Quote and escape Observable strings and chars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## NEXT RELEASE
 
-- ...
+- Quote and escape when printing `string` and `char` in the `Observable` module
+  for function generation
 
 ## 0.22
 

--- a/example/QCheck_runner_test.expected.ocaml4.32
+++ b/example/QCheck_runner_test.expected.ocaml4.32
@@ -82,7 +82,7 @@ Test FAIL_pred_map_commute failed (47 shrink steps):
 
 Test FAIL_fun2_pred_strings failed (1 shrink steps):
 
-{some other string -> false; _ -> true}
+{"some other string" -> false; _ -> true}
 
 --- Failure --------------------------------------------------------------------
 

--- a/example/QCheck_runner_test.expected.ocaml4.64
+++ b/example/QCheck_runner_test.expected.ocaml4.64
@@ -82,7 +82,7 @@ Test FAIL_pred_map_commute failed (77 shrink steps):
 
 Test FAIL_fun2_pred_strings failed (1 shrink steps):
 
-{some other string -> false; _ -> true}
+{"some other string" -> false; _ -> true}
 
 --- Failure --------------------------------------------------------------------
 

--- a/example/QCheck_runner_test.expected.ocaml5.32
+++ b/example/QCheck_runner_test.expected.ocaml5.32
@@ -82,7 +82,7 @@ Test FAIL_pred_map_commute failed (47 shrink steps):
 
 Test FAIL_fun2_pred_strings failed (1 shrink steps):
 
-{some other string -> false; _ -> true}
+{"some other string" -> false; _ -> true}
 
 --- Failure --------------------------------------------------------------------
 

--- a/example/QCheck_runner_test.expected.ocaml5.64
+++ b/example/QCheck_runner_test.expected.ocaml5.64
@@ -82,7 +82,7 @@ Test FAIL_pred_map_commute failed (79 shrink steps):
 
 Test FAIL_fun2_pred_strings failed (1 shrink steps):
 
-{some other string -> false; _ -> true}
+{"some other string" -> false; _ -> true}
 
 --- Failure --------------------------------------------------------------------
 

--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -1005,7 +1005,7 @@ module Observable = struct
   let float : float t = make ~eq:Eq.float Print.float
   let bytes = make ~hash:H.bytes ~eq:Eq.bytes Print.bytes
   let string = make ~hash:H.string ~eq:Eq.string Print.string
-  let char = make ~hash:H.char ~eq:Eq.char Print.char
+  let char = make ~hash:H.char ~eq:Eq.char (sprintf "%C")
 
   let option p =
     make ~hash:(H.opt p.hash) ~eq:(Eq.option p.eq)

--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -1004,7 +1004,7 @@ module Observable = struct
   let int : int t = make ~hash:H.int ~eq:Eq.int Print.int
   let float : float t = make ~eq:Eq.float Print.float
   let bytes = make ~hash:H.bytes ~eq:Eq.bytes Print.bytes
-  let string = make ~hash:H.string ~eq:Eq.string Print.string
+  let string = make ~hash:H.string ~eq:Eq.string (sprintf "%S")
   let char = make ~hash:H.char ~eq:Eq.char (sprintf "%C")
 
   let option p =

--- a/test/core/QCheck_expect_test.expected.ocaml4.32
+++ b/test/core/QCheck_expect_test.expected.ocaml4.32
@@ -511,7 +511,7 @@ Test fail_pred_map_commute failed (47 shrink steps):
 
 Test fail_pred_strings failed (1 shrink steps):
 
-{some other string -> false; _ -> true}
+{"some other string" -> false; _ -> true}
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected.ocaml4.64
+++ b/test/core/QCheck_expect_test.expected.ocaml4.64
@@ -543,7 +543,7 @@ Test fail_pred_map_commute failed (77 shrink steps):
 
 Test fail_pred_strings failed (1 shrink steps):
 
-{some other string -> false; _ -> true}
+{"some other string" -> false; _ -> true}
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected.ocaml5.32
+++ b/test/core/QCheck_expect_test.expected.ocaml5.32
@@ -552,7 +552,7 @@ Test fold_left fold_right uncurried fun last failed (25 shrink steps):
 
 Test fold_left test, fun first failed (66 shrink steps):
 
-({(, 2) -> "a"; _ -> ""}, "", [], [2])
+({("", 2) -> "a"; _ -> ""}, "", [], [2])
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected.ocaml5.32
+++ b/test/core/QCheck_expect_test.expected.ocaml5.32
@@ -521,7 +521,7 @@ Test fail_pred_map_commute failed (47 shrink steps):
 
 Test fail_pred_strings failed (1 shrink steps):
 
-{some other string -> false; _ -> true}
+{"some other string" -> false; _ -> true}
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected.ocaml5.64
+++ b/test/core/QCheck_expect_test.expected.ocaml5.64
@@ -584,7 +584,7 @@ Test fold_left fold_right uncurried fun last failed (25 shrink steps):
 
 Test fold_left test, fun first failed (66 shrink steps):
 
-({(, 2) -> "a"; _ -> ""}, "", [], [2])
+({("", 2) -> "a"; _ -> ""}, "", [], [2])
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected.ocaml5.64
+++ b/test/core/QCheck_expect_test.expected.ocaml5.64
@@ -553,7 +553,7 @@ Test fail_pred_map_commute failed (79 shrink steps):
 
 Test fail_pred_strings failed (1 shrink steps):
 
-{some other string -> false; _ -> true}
+{"some other string" -> false; _ -> true}
 
 --- Failure --------------------------------------------------------------------
 


### PR DESCRIPTION
When recently using QCheck's function generation support, I noticed an issue with its printing of chars and strings.
Consider these two examples:
```ocaml
open QCheck

let test_char =
  Test.make
    (triple char char (fun1 Observable.char bool))
    (fun (c1,c2,f) -> Fn.apply f c1 = Fn.apply f c2)

let _ = QCheck_base_runner.run_tests ~verbose:true [test_char]

let test_string =
  Test.make
    (triple string string (fun1 Observable.string bool))
    (fun (s1,s2,f) -> Fn.apply f s1 = Fn.apply f s2)

let _ = QCheck_base_runner.run_tests ~verbose:true [test_string]
```

resulting in output such as:
```
generated error fail pass / total     time test name
[✗]    1    0    1    0 /  100     0.0s anon_test_1

--- Failure --------------------------------------------------------------------

Test anon_test_1 failed (15 shrink steps):

('a', '\142', {� -> true; _ -> false})
================================================================================
failure (1 tests failed, 0 tests errored, ran 1 tests)
generated error fail pass / total     time test name
[✗]    2    0    1    1 /  100     0.0s anon_test_2

--- Failure --------------------------------------------------------------------

Test anon_test_2 failed (27 shrink steps):

("a", "", { -> false; _ -> true})
```

Note the not-so-helpful function domain printing: `� -> true` and ` -> false`.

This PR therefore offers a quickfix to these two printers, aligning them with the `arbitrary` printers, and thus offering a uniform print out:
```
generated error fail pass / total     time test name
[✗]    1    0    1    0 /  100     0.0s anon_test_1

--- Failure --------------------------------------------------------------------

Test anon_test_1 failed (18 shrink steps):

('a', '_', {'_' -> false; _ -> true})
================================================================================
failure (1 tests failed, 0 tests errored, ran 1 tests)
generated error fail pass / total     time test name
[✗]    1    0    1    0 /  100     0.0s anon_test_2

--- Failure --------------------------------------------------------------------

Test anon_test_2 failed (34 shrink steps):

("a", "", {"" -> false; _ -> true})
================================================================================
failure (1 tests failed, 0 tests errored, ran 1 tests)
```


Looking further,
- I was annoyed by having to duplicate the ad-hoc printers from `arbitrary` one more time, rather than use the `Print` module, supposed to be used for this
- I also noticed that `QCheck2.Print.char` and  `QCheck2.Print.string` already behave like the above, creating a QCheck.Print / QCheck2.Print mismatch for chars and strings :scream: 

I'll therefore file a sister-PR with a breaking change to `QCheck.Print.{char,string}` restoring uniformity and order to the universe... :star: ...then we discuss the preferred solution and whether anyone's (expect) tests may be broken by it.