### PR TITLE
Quote and escape in QCheck.Print.{char,string}, aligning it with QCheck2.Print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## NEXT RELEASE
 
+- Quote and escape in `Print.string` and `Print.char` in the `QCheck` module,
+  mirroring the `QCheck2.Print` module's behaviour
 - Clean-up `QCheck` and `QCheck2` documentation pages
 - Add `exponential` generator to `QCheck`, `QCheck.Gen`, and `QCheck2.Gen`
 - Add `Shrink.bool` and use it in `QCheck.bool`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## NEXT RELEASE
 
 - Quote and escape in `Print.string` and `Print.char` in the `QCheck` module,
-  mirroring the `QCheck2.Print` module's behaviour
+  mirroring the `QCheck2.Print` module's behaviour. Also quote and
+  escape `Print.bytes` in both `QCheck` and `QCheck2`.
 - Clean-up `QCheck` and `QCheck2` documentation pages
 - Add `exponential` generator to `QCheck`, `QCheck.Gen`, and `QCheck2.Gen`
 - Add `Shrink.bool` and use it in `QCheck.bool`

--- a/example/QCheck_runner_test.expected.ocaml4.32
+++ b/example/QCheck_runner_test.expected.ocaml4.32
@@ -82,7 +82,7 @@ Test FAIL_pred_map_commute failed (48 shrink steps):
 
 Test FAIL_fun2_pred_strings failed (2 shrink steps):
 
-{some random string -> true; _ -> false}
+{"some random string" -> true; _ -> false}
 
 --- Failure --------------------------------------------------------------------
 

--- a/example/QCheck_runner_test.expected.ocaml4.64
+++ b/example/QCheck_runner_test.expected.ocaml4.64
@@ -82,7 +82,7 @@ Test FAIL_pred_map_commute failed (77 shrink steps):
 
 Test FAIL_fun2_pred_strings failed (2 shrink steps):
 
-{some random string -> true; _ -> false}
+{"some random string" -> true; _ -> false}
 
 --- Failure --------------------------------------------------------------------
 

--- a/example/QCheck_runner_test.expected.ocaml5.32
+++ b/example/QCheck_runner_test.expected.ocaml5.32
@@ -82,7 +82,7 @@ Test FAIL_pred_map_commute failed (47 shrink steps):
 
 Test FAIL_fun2_pred_strings failed (2 shrink steps):
 
-{some random string -> true; _ -> false}
+{"some random string" -> true; _ -> false}
 
 --- Failure --------------------------------------------------------------------
 

--- a/example/QCheck_runner_test.expected.ocaml5.64
+++ b/example/QCheck_runner_test.expected.ocaml5.64
@@ -82,7 +82,7 @@ Test FAIL_pred_map_commute failed (89 shrink steps):
 
 Test FAIL_fun2_pred_strings failed (2 shrink steps):
 
-{some random string -> true; _ -> false}
+{"some random string" -> true; _ -> false}
 
 --- Failure --------------------------------------------------------------------
 

--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -481,8 +481,8 @@ module Print = struct
   let bool = string_of_bool
   let float = string_of_float
   let bytes = Bytes.to_string
-  let string s = s
-  let char c = String.make 1 c
+  let string s = Printf.sprintf "%S" s
+  let char c = Printf.sprintf "%C" c
 
   let option f = function
     | None -> "None"

--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -479,8 +479,8 @@ module Print = struct
   let int = string_of_int
   let bool = string_of_bool
   let float = string_of_float
-  let bytes = Bytes.to_string
   let string s = Printf.sprintf "%S" s
+  let bytes b = string (Bytes.to_string b)
   let char c = Printf.sprintf "%C" c
 
   let option f = function

--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -7,7 +7,6 @@ all rights reserved.
 (** {1 Quickcheck inspired property-based testing} *)
 
 let poly_compare=compare
-open Printf
 
 module RS = struct
   (* Poor man's splitter for version < 5.0                       *)
@@ -1097,17 +1096,17 @@ let unit : unit arbitrary =
   make ~small:small1 ~shrink:Shrink.nil ~print:Print.unit Gen.unit
 let bool =
   make ~small:small1 ~shrink:Shrink.bool ~print:Print.bool Gen.bool
-let float = make_scalar ~print:string_of_float Gen.float
-let pos_float = make_scalar ~print:string_of_float Gen.pfloat
-let neg_float = make_scalar ~print:string_of_float Gen.nfloat
+let float = make_scalar ~print:Print.float Gen.float
+let pos_float = make_scalar ~print:Print.float Gen.pfloat
+let neg_float = make_scalar ~print:Print.float Gen.nfloat
 
 let float_bound_inclusive bound =
-  make_scalar ~print:string_of_float (Gen.float_bound_inclusive bound)
+  make_scalar ~print:Print.float (Gen.float_bound_inclusive bound)
 
 let float_bound_exclusive bound =
-  make_scalar ~print:string_of_float (Gen.float_bound_exclusive bound)
+  make_scalar ~print:Print.float (Gen.float_bound_exclusive bound)
 
-let float_range low high = make_scalar ~print:string_of_float (Gen.float_range low high)
+let float_range low high = make_scalar ~print:Print.float (Gen.float_range low high)
 
 let exponential mean = make_scalar ~print:Print.float (Gen.exponential mean)
 
@@ -1132,18 +1131,18 @@ let int64 =
 let small_char target c = abs ((Char.code c) - (Char.code target))
 
 let char =
-  make ~print:(sprintf "%C") ~small:(small_char 'a') ~shrink:Shrink.char Gen.char
+  make ~print:Print.char ~small:(small_char 'a') ~shrink:Shrink.char Gen.char
 let printable_char =
-  make ~print:(sprintf "%C") ~small:(small_char 'a') ~shrink:Shrink.char_printable Gen.printable
+  make ~print:Print.char ~small:(small_char 'a') ~shrink:Shrink.char_printable Gen.printable
 let numeral_char =
-  make ~print:(sprintf "%C") ~small:(small_char '0') ~shrink:Shrink.char_numeral Gen.numeral
+  make ~print:Print.char ~small:(small_char '0') ~shrink:Shrink.char_numeral Gen.numeral
 
 let bytes_gen_of_size size gen =
   make ~shrink:Shrink.bytes ~small:Bytes.length
-    ~print:(Print.bytes) (Gen.bytes_size ~gen size)
+    ~print:Print.bytes (Gen.bytes_size ~gen size)
 let bytes_of gen =
   make ~shrink:Shrink.bytes ~small:Bytes.length
-    ~print:(Print.bytes) (Gen.bytes ~gen)
+    ~print:Print.bytes (Gen.bytes ~gen)
 
 let bytes = bytes_of Gen.char
 let bytes_of_size size = bytes_gen_of_size size Gen.char
@@ -1151,14 +1150,14 @@ let bytes_small = bytes_gen_of_size Gen.small_nat Gen.char
 let bytes_small_of gen = bytes_gen_of_size Gen.small_nat gen
 let bytes_printable =
   make ~shrink:(Shrink.bytes ~shrink:Shrink.char_printable) ~small:Bytes.length
-    ~print:(Print.bytes) (Gen.bytes ~gen:Gen.printable)
+    ~print:Print.bytes (Gen.bytes ~gen:Gen.printable)
 
 let string_gen_of_size size gen =
   make ~shrink:Shrink.string ~small:String.length
-    ~print:(sprintf "%S") (Gen.string_size ~gen size)
+    ~print:Print.string (Gen.string_size ~gen size)
 let string_of gen =
   make ~shrink:Shrink.string ~small:String.length
-    ~print:(sprintf "%S") (Gen.string ~gen)
+    ~print:Print.string (Gen.string ~gen)
 
 let string = string_of Gen.char
 let string_of_size size = string_gen_of_size size Gen.char
@@ -1169,23 +1168,23 @@ let string_gen = string_of
 
 let printable_string =
   make ~shrink:(Shrink.string ~shrink:Shrink.char_printable) ~small:String.length
-    ~print:(sprintf "%S") (Gen.string ~gen:Gen.printable)
+    ~print:Print.string (Gen.string ~gen:Gen.printable)
 
 let printable_string_of_size size =
   make ~shrink:(Shrink.string ~shrink:Shrink.char_printable) ~small:String.length
-    ~print:(sprintf "%S") (Gen.string_size ~gen:Gen.printable size)
+    ~print:Print.string (Gen.string_size ~gen:Gen.printable size)
 
 let small_printable_string =
   make ~shrink:(Shrink.string ~shrink:Shrink.char_printable) ~small:String.length
-    ~print:(sprintf "%S") (Gen.string_size ~gen:Gen.printable Gen.small_nat)
+    ~print:Print.string (Gen.string_size ~gen:Gen.printable Gen.small_nat)
 
 let numeral_string =
   make ~shrink:(Shrink.string ~shrink:Shrink.char_numeral) ~small:String.length
-    ~print:(sprintf "%S") (Gen.string ~gen:Gen.numeral)
+    ~print:Print.string (Gen.string ~gen:Gen.numeral)
 
 let numeral_string_of_size size =
   make ~shrink:(Shrink.string ~shrink:Shrink.char_numeral) ~small:String.length
-    ~print:(sprintf "%S") (Gen.string_size ~gen:Gen.numeral size)
+    ~print:Print.string (Gen.string_size ~gen:Gen.numeral size)
 
 let string_printable = printable_string
 let string_printable_of_size = printable_string_of_size

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -797,9 +797,9 @@ module Print = struct
 
   let float = string_of_float
 
-  let bytes = Bytes.to_string
-
   let string s = Printf.sprintf "%S" s
+
+  let bytes b = string (Bytes.to_string b)
 
   let char c = Printf.sprintf "%C" c
 

--- a/test/core/QCheck2_expect_test.expected.ocaml4.32
+++ b/test/core/QCheck2_expect_test.expected.ocaml4.32
@@ -284,25 +284,25 @@ Test printable never produces less than '5 failed (1 shrink steps):
 
 Test bytes are empty failed (8 shrink steps):
 
-a
+"a"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \000 char failed (22 shrink steps):
 
-aaaaaa aaaaaaaaaaaaaaaa
+"aaaaaa\000aaaaaaaaaaaaaaaa"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \255 char failed (59 shrink steps):
 
-aaaaaaaaaaaaaaaaaaaaaaaaaaÿaaaaaaaaaaaaaaaaaaaaaaaa
+"aaaaaaaaaaaaaaaaaaaaaaaaaa\255aaaaaaaaaaaaaaaaaaaaaaaa"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes have unique chars failed (18 shrink steps):
 
-aaaaaaaaaaaaa
+"aaaaaaaaaaaaa"
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck2_expect_test.expected.ocaml4.64
+++ b/test/core/QCheck2_expect_test.expected.ocaml4.64
@@ -348,25 +348,25 @@ Test printable never produces less than '5 failed (1 shrink steps):
 
 Test bytes are empty failed (8 shrink steps):
 
-a
+"a"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \000 char failed (22 shrink steps):
 
-aaaaaa aaaaaaaaaaaaaaaa
+"aaaaaa\000aaaaaaaaaaaaaaaa"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \255 char failed (59 shrink steps):
 
-aaaaaaaaaaaaaaaaaaaaaaaaaaÿaaaaaaaaaaaaaaaaaaaaaaaa
+"aaaaaaaaaaaaaaaaaaaaaaaaaa\255aaaaaaaaaaaaaaaaaaaaaaaa"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes have unique chars failed (18 shrink steps):
 
-aaaaaaaaaaaaa
+"aaaaaaaaaaaaa"
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck2_expect_test.expected.ocaml5.32
+++ b/test/core/QCheck2_expect_test.expected.ocaml5.32
@@ -284,25 +284,25 @@ Test printable never produces less than '5 failed (0 shrink steps):
 
 Test bytes are empty failed (9 shrink steps):
 
-a
+"a"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \000 char failed (55 shrink steps):
 
-aaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"aaaaaaaaaaaaaaa\000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \255 char failed (75 shrink steps):
 
-aaaaaaaÿaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"aaaaaaa\255aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes have unique chars failed (14 shrink steps):
 
-aaaaaaa
+"aaaaaaa"
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck2_expect_test.expected.ocaml5.64
+++ b/test/core/QCheck2_expect_test.expected.ocaml5.64
@@ -340,25 +340,25 @@ Test printable never produces less than '5 failed (0 shrink steps):
 
 Test bytes are empty failed (9 shrink steps):
 
-a
+"a"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \000 char failed (55 shrink steps):
 
-aaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"aaaaaaaaaaaaaaa\000aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \255 char failed (75 shrink steps):
 
-aaaaaaaÿaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+"aaaaaaa\255aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes have unique chars failed (14 shrink steps):
 
-aaaaaaa
+"aaaaaaa"
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected.ocaml4.32
+++ b/test/core/QCheck_expect_test.expected.ocaml4.32
@@ -253,25 +253,25 @@ Test printable never produces less than '5 failed (3 shrink steps):
 
 Test bytes are empty failed (15 shrink steps):
 
-a
+"a"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \000 char failed (8 shrink steps):
 
- 
+"\000"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \255 char failed (14 shrink steps):
 
-ÿ
+"\255"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes have unique chars failed (13 shrink steps):
 
-
+"\129\129"
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected.ocaml4.32
+++ b/test/core/QCheck_expect_test.expected.ocaml4.32
@@ -511,7 +511,7 @@ Test fail_pred_map_commute failed (48 shrink steps):
 
 Test fail_pred_strings failed (2 shrink steps):
 
-{some random string -> true; _ -> false}
+{"some random string" -> true; _ -> false}
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected.ocaml4.64
+++ b/test/core/QCheck_expect_test.expected.ocaml4.64
@@ -543,7 +543,7 @@ Test fail_pred_map_commute failed (77 shrink steps):
 
 Test fail_pred_strings failed (2 shrink steps):
 
-{some random string -> true; _ -> false}
+{"some random string" -> true; _ -> false}
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected.ocaml4.64
+++ b/test/core/QCheck_expect_test.expected.ocaml4.64
@@ -285,25 +285,25 @@ Test printable never produces less than '5 failed (3 shrink steps):
 
 Test bytes are empty failed (15 shrink steps):
 
-a
+"a"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \000 char failed (8 shrink steps):
 
- 
+"\000"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \255 char failed (14 shrink steps):
 
-ÿ
+"\255"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes have unique chars failed (13 shrink steps):
 
-
+"\129\129"
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected.ocaml5.32
+++ b/test/core/QCheck_expect_test.expected.ocaml5.32
@@ -521,7 +521,7 @@ Test fail_pred_map_commute failed (47 shrink steps):
 
 Test fail_pred_strings failed (2 shrink steps):
 
-{some random string -> true; _ -> false}
+{"some random string" -> true; _ -> false}
 
 --- Failure --------------------------------------------------------------------
 
@@ -552,7 +552,7 @@ Test fold_left fold_right uncurried fun last failed (25 shrink steps):
 
 Test fold_left test, fun first failed (66 shrink steps):
 
-({(, 2) -> "a"; _ -> ""}, "", [], [2])
+({("", 2) -> "a"; _ -> ""}, "", [], [2])
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected.ocaml5.32
+++ b/test/core/QCheck_expect_test.expected.ocaml5.32
@@ -263,25 +263,25 @@ Test printable never produces less than '5 failed (0 shrink steps):
 
 Test bytes are empty failed (13 shrink steps):
 
-a
+"a"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \000 char failed (13 shrink steps):
 
- 
+"\000"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \255 char failed (15 shrink steps):
 
-я
+"\255"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes have unique chars failed (14 shrink steps):
 
-ии
+"\232\232"
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected.ocaml5.64
+++ b/test/core/QCheck_expect_test.expected.ocaml5.64
@@ -295,25 +295,25 @@ Test printable never produces less than '5 failed (0 shrink steps):
 
 Test bytes are empty failed (13 shrink steps):
 
-a
+"a"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \000 char failed (13 shrink steps):
 
- 
+"\000"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes never has a \255 char failed (15 shrink steps):
 
-я
+"\255"
 
 --- Failure --------------------------------------------------------------------
 
 Test bytes have unique chars failed (14 shrink steps):
 
-ии
+"\232\232"
 
 --- Failure --------------------------------------------------------------------
 

--- a/test/core/QCheck_expect_test.expected.ocaml5.64
+++ b/test/core/QCheck_expect_test.expected.ocaml5.64
@@ -553,7 +553,7 @@ Test fail_pred_map_commute failed (89 shrink steps):
 
 Test fail_pred_strings failed (2 shrink steps):
 
-{some random string -> true; _ -> false}
+{"some random string" -> true; _ -> false}
 
 --- Failure --------------------------------------------------------------------
 
@@ -584,7 +584,7 @@ Test fold_left fold_right uncurried fun last failed (25 shrink steps):
 
 Test fold_left test, fun first failed (66 shrink steps):
 
-({(, 2) -> "a"; _ -> ""}, "", [], [2])
+({("", 2) -> "a"; _ -> ""}, "", [], [2])
 
 --- Failure --------------------------------------------------------------------
 


### PR DESCRIPTION
As mentioned in #296 
- the `QCheck.Observable.{char,string}` function printers yield unhelpful output, despite using `QCheck.Print.{char,string}`
- quickfixing it like #296, adds another ad-hoc copy, rather than fixing the root cause, namely `QCheck.Observable.{char,string}`
- `QCheck2.Print.{char,string}` already quotes and escapes, creating a `QCheck.Print` / `QCheck2.Print` mismatch for chars and strings

This PR thus suggests the breaking change of fixing `QCheck.Print.{char,string}`.
This further opens up for cleaning up some of the ad-hoc printers in the `arbitrary` combinators (commit d1c1fee)

I'm hoping for fellow QCheck users and developers to chip in to the discussion and share which PR and `QCheck2.Print.{char,string}` they prefer... :pray: :slightly_smiling_face: 