### PR TITLE
Document `dune` usage in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## NEXT RELEASE
 
-- ...
+- Document `dune` usage in README
 
 ## 0.23
 

--- a/README.adoc
+++ b/README.adoc
@@ -438,3 +438,59 @@ Starting with 0.9, the library is split into several components:
 
 Normally, for contributors,
 `opam pin https://github.com/c-cube/qcheck` will pin all these packages.
+
+
+=== Usage from dune
+
+We can use the buggy test from above using the `qcheck` opam package:
+
+[source,OCaml]
+----
+(* test.ml *)
+let test =
+  QCheck.Test.make ~count:1000 ~name:"my_buggy_test"
+   QCheck.(list small_nat)
+   (fun l -> List.rev l = l)
+
+let _ = QCheck_runner.run_tests_main [test]
+----
+
+with the following `dune` file:
+
+[source]
+----
+(test
+ (name test)
+ (modules test)
+ (libraries qcheck)
+)
+----
+
+and run it with `dune exec ./test.exe` or `dune runtest`.
+
+
+Using the `qcheck-core` package instead, we have to adapt the last line of the
+example to use `QCheck_base_runner`:
+
+[source,OCaml]
+----
+(* test.ml *)
+let test =
+  QCheck.Test.make ~count:1000 ~name:"my_buggy_test"
+   QCheck.(list small_nat)
+   (fun l -> List.rev l = l)
+
+let _ = QCheck_base_runner.run_tests_main [test]
+----
+
+and adjust the `dune` file accordingly to use `qcheck-core` and its
+`qcheck-core.runner` sub-package:
+
+[source]
+----
+(test
+ (name test)
+ (modules test)
+ (libraries qcheck-core qcheck-core.runner)
+)
+----

--- a/README.adoc
+++ b/README.adoc
@@ -34,13 +34,21 @@ changed in lots of small ways (in the right direction, I hope) so the code
 will not work any more.
 <<examples>> is an updated version of the blog post's examples.
 
-== Build
+== Build and Install
+
+You can install qcheck via opam:
+
+    $ opam install qcheck
+
+The `qcheck` package is offered for compatibility.
+For a bare-bones installation you can use the `qcheck-core` package:
+
+    $ opam install qcheck-core
+
+To build the library from source
 
     $ make
 
-You can use opam:
-
-    $ opam install qcheck
 
 == License
 

--- a/README.adoc
+++ b/README.adoc
@@ -469,8 +469,9 @@ with the following `dune` file:
 and run it with `dune exec ./test.exe` or `dune runtest`.
 
 
-Using the `qcheck-core` package instead, we have to adapt the last line of the
-example to use `QCheck_base_runner`:
+To keep things minimal or if you are using `(implicit_transitive_deps false)`
+in dune, you may want to use the `qcheck-core` package instead. To do so,
+we have to adapt the last line of the example to use `QCheck_base_runner`:
 
 [source,OCaml]
 ----


### PR DESCRIPTION
Fixes #270 

While at it, the PR also elaborates a bit on the installation instructions.