### PR TITLE
Prepare for 5.2 AST bump

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
   a `QCheck2` integrated shrinking example
 - Document `QCHECK_MSG_INTERVAL` introduced in 0.20
 - Add `QCheck{,2}.Gen.map{4,5}` combinators
+- [ppx_deriving_qcheck] Support `ppxlib.0.36.0` based on the OCaml 5.2 AST
 
 ## 0.24
 

--- a/ppx_deriving_qcheck.opam
+++ b/ppx_deriving_qcheck.opam
@@ -11,7 +11,7 @@ depends: [
   "dune" {>= "2.8.0"}
   "ocaml" {>= "4.08.0"}
   "qcheck-core" {>= "0.24"}
-  "ppxlib" {>= "0.22.0" & < "0.36.0"}
+  "ppxlib" {>= "0.36.0"}
   "ppx_deriving" {>= "5.2.1" & < "6.1.0"}
   "odoc" {with-doc}
   "alcotest" {with-test & >= "1.4.0" }

--- a/ppx_deriving_qcheck.opam
+++ b/ppx_deriving_qcheck.opam
@@ -12,7 +12,7 @@ depends: [
   "ocaml" {>= "4.08.0"}
   "qcheck-core" {>= "0.24"}
   "ppxlib" {>= "0.36.0"}
-  "ppx_deriving" {>= "5.2.1" & < "6.1.0"}
+  "ppx_deriving" {>= "6.1.0"}
   "odoc" {with-doc}
   "alcotest" {with-test & >= "1.4.0" }
   "qcheck-alcotest" {with-test & >= "0.24"}

--- a/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
+++ b/src/ppx_deriving_qcheck/ppx_deriving_qcheck.ml
@@ -57,9 +57,15 @@ let pattern_name pat : string =
     the actual body using these args. *)
 let rec args_and_body expr : (string list * expression) =
   match expr.pexp_desc with
-  | Pexp_fun (Nolabel, _, pat, expr) ->
+  | Pexp_function (fargs, _constraint, Pfunction_body expr) ->
      let (args, body) = args_and_body expr in
-     (pattern_name pat :: args, body)
+     let pats =
+       List.filter_map (function
+         | { pparam_desc = Pparam_val (Nolabel, _, p); _ } -> Some (pattern_name p)
+         | _ -> None
+       ) fargs
+     in
+     (pats @ args, body)
   | _ -> ([], expr)
 
 (** {2. Recursive generators} *)

--- a/test/ppx_deriving_qcheck/deriver/qcheck/test_textual.ml
+++ b/test/ppx_deriving_qcheck/deriver/qcheck/test_textual.ml
@@ -807,7 +807,13 @@ let test_recursive_poly_variant () =
   let actual =
     f @@ extract [%stri type 'a tree = [ `Leaf of 'a | `Node of 'a tree * 'a tree ]]
   in
-  check_eq ~expected ~actual "deriving recursive polymorphic variants"
+  (* On OCaml 5.1 and earlier this test hits a cornercase of the ppxlib AST-mappings
+     to move the type annotation when pretty printed and ultimately fail this test
+     https://github.com/ocaml-ppx/ppxlib/blob/37d7ee13f4dcac44de5244a1c1e19652a5880075/astlib/migrate_501_502.ml#L173-L181
+  *)
+  if Sys.(ocaml_release.major,ocaml_release.minor) < (5,1)
+  then ()
+  else check_eq ~expected ~actual "deriving recursive polymorphic variants"
 
 (* Regression test: https://github.com/c-cube/qcheck/issues/213 *)
 let test_unused_variable () =

--- a/test/ppx_deriving_qcheck/deriver/qcheck/test_textual.ml
+++ b/test/ppx_deriving_qcheck/deriver/qcheck/test_textual.ml
@@ -811,7 +811,9 @@ let test_recursive_poly_variant () =
      to move the type annotation when pretty printed and ultimately fail this test
      https://github.com/ocaml-ppx/ppxlib/blob/37d7ee13f4dcac44de5244a1c1e19652a5880075/astlib/migrate_501_502.ml#L173-L181
   *)
-  if Sys.(ocaml_release.major,ocaml_release.minor) < (5,1)
+  let ocaml_release =
+    Scanf.sscanf Sys.ocaml_version "%i.%i" (fun major minor -> (major,minor)) in
+  if ocaml_release < (5,1)
   then ()
   else check_eq ~expected ~actual "deriving recursive polymorphic variants"
 

--- a/test/ppx_deriving_qcheck/deriver/qcheck2/test_textual.ml
+++ b/test/ppx_deriving_qcheck/deriver/qcheck2/test_textual.ml
@@ -89,7 +89,7 @@ let test_int64' () =
  *     ]
  *   in
  *   let actual = f @@ extract [%stri type t = Bytes.t ] in
- * 
+ *
  *   check_eq ~expected ~actual "deriving int64" *)
 
 let test_tuple () =
@@ -454,7 +454,7 @@ let test_expr () =
               | Lt of expr * expr]
   in
   check_eq ~expected ~actual "deriving expr"
-  
+
 let test_forest () =
   let expected =
     [
@@ -719,7 +719,13 @@ let test_recursive_poly_variant () =
   let actual =
     f @@ extract [%stri type 'a tree = [ `Leaf of 'a | `Node of 'a tree * 'a tree ]]
   in
-  check_eq ~expected ~actual "deriving recursive polymorphic variants"
+  (* On OCaml 5.1 and earlier this test hits a cornercase of the ppxlib AST-mappings
+     to move the type annotation when pretty printed and ultimately fail this test
+     https://github.com/ocaml-ppx/ppxlib/blob/37d7ee13f4dcac44de5244a1c1e19652a5880075/astlib/migrate_501_502.ml#L173-L181
+  *)
+  if Sys.(ocaml_release.major,ocaml_release.minor) < (5,1)
+  then ()
+  else check_eq ~expected ~actual "deriving recursive polymorphic variants"
 
 let () =
   Alcotest.(

--- a/test/ppx_deriving_qcheck/deriver/qcheck2/test_textual.ml
+++ b/test/ppx_deriving_qcheck/deriver/qcheck2/test_textual.ml
@@ -723,7 +723,9 @@ let test_recursive_poly_variant () =
      to move the type annotation when pretty printed and ultimately fail this test
      https://github.com/ocaml-ppx/ppxlib/blob/37d7ee13f4dcac44de5244a1c1e19652a5880075/astlib/migrate_501_502.ml#L173-L181
   *)
-  if Sys.(ocaml_release.major,ocaml_release.minor) < (5,1)
+  let ocaml_release =
+    Scanf.sscanf Sys.ocaml_version "%i.%i" (fun major minor -> (major,minor)) in
+  if ocaml_release < (5,1)
   then ()
   else check_eq ~expected ~actual "deriving recursive polymorphic variants"
 


### PR DESCRIPTION
In preparation for https://github.com/ocaml/opam-repository/pull/27478 there is WIP documentation about the AST bump on the ppxlib wiki: https://github.com/ocaml-ppx/ppxlib/wiki/Upgrading-to-ppxlib-0.36.0