### PR TITLE
Fix asciidoc in README and add a workflow to check it

### DIFF
--- a/.github/workflows/check-asciidoc.yml
+++ b/.github/workflows/check-asciidoc.yml
@@ -1,0 +1,17 @@
+name: build
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+jobs:
+  run:
+    name: Check asciidoc
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: sudo apt install asciidoc-base
+    - run: asciidoc README.adoc
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 - Adjust `stats` computation of average and standard deviation to
   limit precision loss, print both using scientific notation, and
   workaround MinGW float printing to also pass expect tests
+- Fix dune snippets missing a language specifier in README.adoc
+  causing `asciidoc` to error
 
 ## 0.24
 

--- a/README.adoc
+++ b/README.adoc
@@ -457,7 +457,7 @@ let _ = QCheck_runner.run_tests_main [test]
 
 with the following `dune` file:
 
-[source]
+[source,lisp]
 ----
 (test
  (name test)
@@ -487,7 +487,7 @@ let _ = QCheck_base_runner.run_tests_main [test]
 and adjust the `dune` file accordingly to use `qcheck-core` and its
 `qcheck-core.runner` sub-package:
 
-[source]
+[source,lisp]
 ----
 (test
  (name test)

--- a/README.adoc
+++ b/README.adoc
@@ -23,8 +23,6 @@ of interest:
 Jan Midtgaard (@jmid) has http://janmidtgaard.dk/quickcheck/index.html[a lecture] about
 property-based testing that relies on QCheck.
 
-toc::[]
-
 == Use
 
 See the documentation. I also wrote


### PR DESCRIPTION
Prior to opening the PR, I've tested that the workflow indeed fails on the current README.adoc

Fixes #325 