### PR TITLE
CI: Build and test on 5.3.0 too - and target Apple silicon macOS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,7 @@ jobs:
           - "4.14"
           - "5.0"
           - "5.2"
+          - "5.3"
         exclude:
           - os: windows-latest
             ocaml-compiler: "4.08"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - macos-13
+          - macos-latest
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,8 @@ jobs:
           - "5.2"
           - "5.3"
         exclude:
+          - os: macos-latest
+            ocaml-compiler: "4.08"
           - os: windows-latest
             ocaml-compiler: "4.08"
           - os: windows-latest


### PR DESCRIPTION
This is the latest and most stable 5.* release after all :slightly_smiling_face: 