### PR TITLE
Add CI testing on 32-bit i386 of OCaml 4.14 and 5.3 via Docker containers

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,10 +32,39 @@ jobs:
             ocaml-compiler: "4.12"
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v4
-    - uses: ocaml/setup-ocaml@v3
-      with:
-        ocaml-compiler: ${{ matrix.ocaml-compiler }}
-    - run: opam install . --deps-only --with-test
-    - run: opam exec -- dune build
-    - run: opam exec -- dune runtest
+      - uses: actions/checkout@v4
+      - uses: ocaml/setup-ocaml@v3
+        with:
+          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+      - run: opam install . --deps-only --with-test
+      - run: opam exec -- dune build
+      - run: opam exec -- dune runtest
+
+  i386:
+    strategy:
+      fail-fast: false
+      matrix:
+        container-image:
+          - ocaml/opam:debian-12-ocaml-4.14
+          - ocaml/opam:debian-12-ocaml-5.3
+    runs-on: ubuntu-latest
+    container:
+      image: ${{ matrix.container-image }}
+      options: --platform linux/i386
+    steps:
+      # GitHub insists on HOME=/github/home which clashes with the opam image setup
+      - name: Setup and init opam
+        run: |
+          sudo cp /usr/bin/opam-2.3 /usr/bin/opam
+          cd /home/opam && HOME=/home/opam opam init -y
+      - name: Checkout repository
+        # See https://github.com/actions/checkout/issues/334
+        uses: actions/checkout@v1
+      - name: Setup repo and install dependencies
+        run: |
+          sudo chown -R opam:opam .
+          HOME=/home/opam opam install . --deps-only --with-test
+      - name: Build
+        run: HOME=/home/opam opam exec -- dune build
+      - name: Run the testsuite
+        run: HOME=/home/opam opam exec -- dune runtest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,10 +54,11 @@ jobs:
       options: --platform linux/i386
     steps:
       # GitHub insists on HOME=/github/home which clashes with the opam image setup
-      - name: Setup and init opam
+      - name: Setup, init, and update opam
         run: |
           sudo cp /usr/bin/opam-2.3 /usr/bin/opam
           cd /home/opam && HOME=/home/opam opam init -y
+          git -C /home/opam/opam-repository pull origin master && HOME=/home/opam opam update -y
       - name: Checkout repository
         # See https://github.com/actions/checkout/issues/334
         uses: actions/checkout@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
       - uses: ocaml/setup-ocaml@v3
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+      - run: opam update -y
       - run: opam install . --deps-only --with-test
       - run: opam exec -- dune build
       - run: opam exec -- dune runtest


### PR DESCRIPTION
This PR adds CI tests on 32-bit i386 of OCaml 4.14 and 5.3 via Docker containers.

Background:
The PRNG changed in OCaml5, meaning outputs differ between 4 and 5, even when run with the same seed.
On top, OCaml supports 32-bit (on OCaml5 only via bytecode). Again, this means different output behaviour between 32-bit and 64-bit, resulting in 4 combinations overall, that QCheck supports.

Our current CI only tests on 64-bit, thus leaving a blind angle.
More than once have I discovered out-of-date 32-bit expect test files during a release to the opam-repo, which tests 32-bit in its CI. This is a bit late to catch something that ideally would come with each PR.
This PR thus offers exactly that: CI testing of 32-bit builds via Docker containers.
I've only added 2 entries - one representative (4.14 and 5.3) from each side of the PRNG split.

The addition battles a bit to make the ends meet between the prebuilt opam-images using `HOME=/home/opam` and an accompanying `opam` user with `~/.opamrc` etc, and GitHub actions insisting on adding `-e "HOME=/github/home"` last when invoking `docker` :shrug: 