### PR TITLE
Document QCHECK_MSG_INTERVAL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
   about internal state, and fix a range of documentation reference warnings
 - Reorganize and polish the `README`, rewrite it to use `qcheck-core`, and add
   a `QCheck2` integrated shrinking example
+- Document `QCHECK_MSG_INTERVAL` introduced in 0.20
 
 ## 0.24
 

--- a/src/runner/QCheck_base_runner.mli
+++ b/src/runner/QCheck_base_runner.mli
@@ -50,6 +50,21 @@ val set_verbose : bool -> unit
 val set_long_tests : bool -> unit
 (** Change the value of [long_tests ()] *)
 
+
+(** {2 Console message printing}
+
+    In verbose mode, by default [QCheck_base_runner] prints frequent sub-second
+    messages suitable for an interactive console test run. This behaviour can be
+    changed by the environment variable [QCHECK_MSG_INTERVAL]. Intervals are
+    given in seconds and can also be decimal numbers. For example, setting
+    {[
+       QCHECK_MSG_INTERVAL=7.5
+    ]}
+    will only print a console message every 7.5 seconds. This feature can be
+    useful in a CI context, where updates are printed on consecutive lines and
+    one may want to avoid overflowing the CI log files with too many lines.
+*)
+
 val get_time_between_msg : unit -> float
 (** Get the minimum time to wait between printing messages.
     @since 0.9 *)

--- a/src/runner/QCheck_base_runner.mli
+++ b/src/runner/QCheck_base_runner.mli
@@ -66,11 +66,11 @@ val set_long_tests : bool -> unit
 *)
 
 val get_time_between_msg : unit -> float
-(** Get the minimum time to wait between printing messages.
+(** Get the minimum time (in seconds) to wait between printing messages.
     @since 0.9 *)
 
 val set_time_between_msg : float -> unit
-(** Set the minimum time between messages.
+(** Set the minimum time (in seconds) between messages.
     @since 0.9 *)
 
 

--- a/src/runner/QCheck_base_runner.mli
+++ b/src/runner/QCheck_base_runner.mli
@@ -70,7 +70,7 @@ val get_time_between_msg : unit -> float
     @since 0.9 *)
 
 val set_time_between_msg : float -> unit
-(** Set the minimum tiem between messages.
+(** Set the minimum time between messages.
     @since 0.9 *)
 
 

--- a/src/runner/QCheck_base_runner.mli
+++ b/src/runner/QCheck_base_runner.mli
@@ -6,9 +6,9 @@ all rights reserved.
 
 (** {1 Runners for Tests}
 
-    Once you built some tests using {!QCheck2.Test.make}, you need to
-    run the tests. This module contains several {b runners},
-    which are designed to run every test and report the result.
+    Once you have built tests using {!QCheck.Test.make} or {!QCheck2.Test.make},
+    you need to run them. This module contains several {b runners}, which are
+    designed to run every test and report the result.
 
     By default, you can use {!run_tests} in a test program as follows:
     {[


### PR DESCRIPTION
#259 added `QCHECK_MSG_INTERVAL` which is helpful to avoid overflowing CI logs.
However it did not document its existence beyond the CHANGELOG and the source code.
This PR adds the missing documentation to `QCheck_base_runner` and also polishes the existing docs a bit.