### PR TITLE
Make CI green again (sic)

### DIFF
--- a/.github/workflows/check-asciidoc.yml
+++ b/.github/workflows/check-asciidoc.yml
@@ -11,7 +11,8 @@ jobs:
     name: Check asciidoc
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
-    - run: sudo apt install asciidoc-base
-    - run: asciidoc README.adoc
-
+      - uses: actions/checkout@v4
+      - run: |
+          sudo apt-get update -y
+          sudo apt-get install -y asciidoc-base
+      - run: asciidoc README.adoc

--- a/ppx_deriving_qcheck.opam
+++ b/ppx_deriving_qcheck.opam
@@ -11,8 +11,8 @@ depends: [
   "dune" {>= "2.8.0"}
   "ocaml" {>= "4.08.0"}
   "qcheck-core" {>= "0.24"}
-  "ppxlib" {>= "0.22.0"}
-  "ppx_deriving" {>= "5.2.1"}
+  "ppxlib" {>= "0.22.0" & < "0.36.0"}
+  "ppx_deriving" {>= "5.2.1" & < "6.1.0"}
   "odoc" {with-doc}
   "alcotest" {with-test & >= "1.4.0" }
   "qcheck-alcotest" {with-test & >= "0.24"}


### PR DESCRIPTION
The initial CI run in #339 revealed a couple of problems
- the asciidoc checking workflow is missing an `apt-get update`
- the ppx_deriving_qcheck package is missing upper bounds (there's a fix to push them in #331)

This PR takes the first step of getting the CI green again. Afterwards we can take on #339 and lift the bounds with #331.