### PR TITLE
Add `QCheck{,2}.Gen.map{4,5}` combinators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - Reorganize and polish the `README`, rewrite it to use `qcheck-core`, and add
   a `QCheck2` integrated shrinking example
 - Document `QCHECK_MSG_INTERVAL` introduced in 0.20
+- Add `QCheck{,2}.Gen.map{4,5}` combinators
 
 ## 0.24
 

--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -121,6 +121,8 @@ module Gen = struct
   let map f x st = f (x st)
   let map2 f x y st = f (x st) (y st)
   let map3 f x y z st = f (x st) (y st) (z st)
+  let map4 f x y z v st = f (x st) (y st) (z st) (v st)
+  let map5 f x y z v w st = f (x st) (y st) (z st) (v st) (w st)
   let map_keep_input f gen st = let x = gen st in x, f x
   let (>|=) x f st = f (x st)
   let (<$>) f x st = f (x st)

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -169,6 +169,14 @@ module Gen : sig
   (** [map3 f g1 g2 g3] transforms three generators [g1], [g2], and [g3] by applying [f]
       to each triple of generated elements. *)
 
+  val map4 : ('a -> 'b -> 'c -> 'd -> 'e) -> 'a t -> 'b t -> 'c t -> 'd t -> 'e t
+  (** [map4 f g1 g2 g3 g4] transforms four generators [g1], [g2], [g3], and [g4]
+      by applying [f] to each quadruple of generated elements. *)
+
+  val map5 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f) -> 'a t -> 'b t -> 'c t -> 'd t -> 'e t -> 'f t
+  (** [map5 f g1 g2 g3 g4 g5] transforms five generators [g1], [g2], [g3], [g4],
+      and [g5] by applying [f] to each quintuple of generated elements. *)
+
   val map_keep_input : ('a -> 'b) -> 'a t -> ('a * 'b) t
   (** [map_keep_input f g] transforms a generator [g] by applying [f] to each generated element.
       Returns both the generated element from [g] and the output from [f]. *)

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -330,9 +330,19 @@ module Gen = struct
   let liftA3 (f : 'a -> 'b -> 'c -> 'd) (a : 'a t) (b : 'b t) (c : 'c t) : 'd t =
     (a >|= f) <*> b <*> c
 
+  let liftA4 (f : 'a -> 'b -> 'c -> 'd -> 'e) (a : 'a t) (b : 'b t) (c : 'c t) (d : 'd t) : 'e t =
+    (a >|= f) <*> b <*> c <*> d
+
+  let liftA5 (f : 'a -> 'b -> 'c -> 'd -> 'e -> 'f) (a : 'a t) (b : 'b t) (c : 'c t) (d : 'd t) (e : 'e t) : 'f t =
+    (a >|= f) <*> b <*> c <*> d <*> e
+
   let map2 = liftA2
 
   let map3 = liftA3
+
+  let map4 = liftA4
+
+  let map5 = liftA5
 
   let return = pure
 

--- a/src/core/QCheck2.mli
+++ b/src/core/QCheck2.mli
@@ -924,13 +924,13 @@ module Gen : sig
       {b and the values are unrelated}. A good rule of thumb is: if the values could be generated
       in parallel, then you can use an applicative function to combine those generators.
 
-      Note that while [map2] and [map3] are provided, you can use functions with more than 3
-      arguments (and that is where the [<*>] operator alias really shines):
+      Note that while [map2], [map3], [map4], and [map5] are provided, you can use functions
+      with more than 5 arguments (this is where the [<*>] operator alias shines):
 
       {[
         val complex_function : bool -> string -> int -> string -> int64 -> some_big_type
 
-        (* Verbose version, using map3 and ap *)
+        (* Verbose version, using map3 and ap to mimic map5 *)
         let big_type_gen : some_big_type Gen.t = Gen.(
             ap (
               ap (
@@ -1020,6 +1020,20 @@ module Gen : sig
       to each triple of generated elements.
 
       Shrinks on [gen1], then [gen2], and then [gen3].
+  *)
+
+  val map4 : ('a -> 'b -> 'c -> 'd -> 'e) -> 'a t -> 'b t -> 'c t -> 'd t -> 'e t
+  (** [map4 f gen1 gen2 gen3 gen4] transforms four generators [gen1], [gen2], [gen3],
+      and [gen4] by applying [f] to each quadruple of generated elements.
+
+      Shrinks on [gen1], then [gen2], [gen3], and then [gen4].
+  *)
+
+  val map5 : ('a -> 'b -> 'c -> 'd -> 'e -> 'f) -> 'a t -> 'b t -> 'c t -> 'd t -> 'e t -> 'f t
+  (** [map5 f gen1 gen2 gen3 gen4 gen5] transforms five generators [gen1], [gen2], [gen3], [gen4],
+      and [gen5] by applying [f] to each quintuple of generated elements.
+
+      Shrinks on [gen1], then [gen2], [gen3], [gen4], and then [gen5].
   *)
 
   val ap : ('a -> 'b) t -> 'a t -> 'b t


### PR DESCRIPTION
While hacking on some `QCheck-STM` tests in ocaml-multicore/multicoretests#547 I found myself missing `QCheck.Gen.map4`. This PR therefore adds `map4` and `map5` combinators to both `QCheck.Gen` and `QCheck2.Gen`,
so that they each support `map`s of arity 1 to 5.