### PR TITLE
Start message timing from unconditional first print

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## NEXT RELEASE
 
-- ...
+- Fix `QCHECK_MSG_INTERVAL` not being applied to the first in-progress message
 
 ## 0.25
 

--- a/src/runner/QCheck_base_runner.ml
+++ b/src/runner/QCheck_base_runner.ml
@@ -412,16 +412,12 @@ let run_tests
     let rand = Random.State.copy rand in
     let expected = expect long cell in
     let start = Unix.gettimeofday () in
-    (* Reset last message timing to always print out a starting 0/X message for
-    each test *)
-    last_msg := 0.0;
     let c = {
       start; expected; gen = 0;
       passed = 0; failed = 0; errored = 0;
     } in
-    let now=Unix.gettimeofday() in
-    if verbose && now -. !last_msg > get_time_between_msg () then
-      (last_msg := now;
+    if verbose then
+      (last_msg := Unix.gettimeofday();
       Printf.fprintf out "%s[ ] %a %s%!"
         (if colors then Color.reset_line else "")
         (pp_counter ~size) c (T.get_name cell));

--- a/src/runner/QCheck_base_runner.ml
+++ b/src/runner/QCheck_base_runner.ml
@@ -308,6 +308,7 @@ let callback ~size ~out ~verbose ~colors c name cell r =
     else QCheck2.TestResult.is_failed r in
   let color = if pass then `Green else `Red in
   if verbose then (
+    (* print final test status line regardless of rate-limiting for responsive user feedback *)
     Printf.fprintf out "%s[%a] %a %s\n%!"
       (if colors then Color.reset_line else "\n")
       (Color.pp_str_c ~bold:true ~colors color) (if pass then "✓" else "✗")
@@ -416,6 +417,7 @@ let run_tests
       passed = 0; failed = 0; errored = 0;
     } in
     if verbose then (
+      (* print initial test status line regardless of rate-limiting for responsive user feedback *)
       last_msg := Unix.gettimeofday();
       Printf.fprintf out "%s[ ] %a %s%!"
         (if colors then Color.reset_line else "")

--- a/src/runner/QCheck_base_runner.ml
+++ b/src/runner/QCheck_base_runner.ml
@@ -417,10 +417,10 @@ let run_tests
     } in
     let now=Unix.gettimeofday() in
     if verbose && now -. !last_msg > get_time_between_msg () then
-      last_msg := now;
+      (last_msg := now;
       Printf.fprintf out "%s[ ] %a %s%!"
         (if colors then Color.reset_line else "")
-        (pp_counter ~size) c (T.get_name cell);
+        (pp_counter ~size) c (T.get_name cell));
     let r = QCheck2.Test.check_cell ~long ~rand
         ~handler:(handler ~colors ~debug_shrink ~debug_shrink_list
                     ~size ~out ~verbose c).handler

--- a/src/runner/QCheck_base_runner.ml
+++ b/src/runner/QCheck_base_runner.ml
@@ -407,7 +407,6 @@ let run_tests
       "%*s %*s %*s %*s / %*s     time test name\n%!"
       (size + 4) "generated" size "error"
       size "fail" size "pass" size "total";
-
   let aux_map (T.Test cell) =
     let rand = Random.State.copy rand in
     let expected = expect long cell in
@@ -416,8 +415,8 @@ let run_tests
       start; expected; gen = 0;
       passed = 0; failed = 0; errored = 0;
     } in
-    if verbose then
-      (last_msg := Unix.gettimeofday();
+    if verbose then (
+      last_msg := Unix.gettimeofday();
       Printf.fprintf out "%s[ ] %a %s%!"
         (if colors then Color.reset_line else "")
         (pp_counter ~size) c (T.get_name cell));

--- a/src/runner/QCheck_base_runner.ml
+++ b/src/runner/QCheck_base_runner.ml
@@ -415,7 +415,9 @@ let run_tests
       start; expected; gen = 0;
       passed = 0; failed = 0; errored = 0;
     } in
-    if verbose then
+    let now=Unix.gettimeofday() in
+    if verbose && now -. !last_msg > get_time_between_msg () then
+      last_msg := now;
       Printf.fprintf out "%s[ ] %a %s%!"
         (if colors then Color.reset_line else "")
         (pp_counter ~size) c (T.get_name cell);

--- a/src/runner/QCheck_base_runner.ml
+++ b/src/runner/QCheck_base_runner.ml
@@ -407,10 +407,14 @@ let run_tests
       "%*s %*s %*s %*s / %*s     time test name\n%!"
       (size + 4) "generated" size "error"
       size "fail" size "pass" size "total";
+
   let aux_map (T.Test cell) =
     let rand = Random.State.copy rand in
     let expected = expect long cell in
     let start = Unix.gettimeofday () in
+    (* Reset last message timing to always print out a starting 0/X message for
+    each test *)
+    last_msg := 0.0;
     let c = {
       start; expected; gen = 0;
       passed = 0; failed = 0; errored = 0;

--- a/src/runner/QCheck_base_runner.mli
+++ b/src/runner/QCheck_base_runner.mli
@@ -63,6 +63,9 @@ val set_long_tests : bool -> unit
     will only print a console message every 7.5 seconds. This feature can be
     useful in a CI context, where updates are printed on consecutive lines and
     one may want to avoid overflowing the CI log files with too many lines.
+
+    Note: The start and finishing message for each test is printed eagerly
+    in verbose mode regardless of the specified message interval.
 *)
 
 val get_time_between_msg : unit -> float


### PR DESCRIPTION
The two other locations in the runner for printing intermediate messages follow a rate-limiting pattern:

https://github.com/c-cube/qcheck/blob/196b9837743a785a7837fcc496bf09ef3950cd69/src/runner/QCheck_base_runner.ml#L277-L284

https://github.com/c-cube/qcheck/blob/196b9837743a785a7837fcc496bf09ef3950cd69/src/runner/QCheck_base_runner.ml#L297-L302

But not at 
https://github.com/c-cube/qcheck/blob/196b9837743a785a7837fcc496bf09ef3950cd69/src/runner/QCheck_base_runner.ml#L418-L421