### PR TITLE
Document QCheck.Shrink invariants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## NEXT RELEASE
 
+- Document `Shrink` invariants in the `QCheck` module
 - Fix a qcheck-ounit test suite failure on OCaml 5.4, removing a needless extra newline
 - Fix QCheck2 `float_range` operator which would fail on negative bounds
 - Fix `QCHECK_MSG_INTERVAL` not being applied to the first in-progress message

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -776,6 +776,13 @@ end
 
     Shrinking is defined as a type {!Shrink.t} that takes an argument to shrink
     and produces an iterator of type {!Iter.t} of shrinking candidates.
+
+    ⚠️ In order to function well, a shrinker must:
+    - never return its argument as a shrinking candidate, and
+    - return shrinking candidates which are smaller by some termination measure
+      ([list] length, tree depth, number of bits, ...)
+
+    Failure to do so, may result in an infinite shrinker loop.
 *)
 
 (** {2 Iterators} *)
@@ -872,8 +879,11 @@ module Shrink : sig
   (** The [Shrink] module contains combinators to build up composite shrinkers
       for user-defined types
 
-      Warning: A hand-written shrinker returning its own argument, will cause
-      QCheck's shrinking phase to loop infinitely. *)
+      ⚠️ Warning: [QCheck]'s shrinking phase may loop infinitely if
+      - the shrinker returns its own argument as a shrinking candidate, or
+      - fails to return a strictly smaller shrinking candidate by some termination measure
+        (e.g., a [list] permutation may lead to an infinite shrinking cycle).
+  *)
 
   type 'a t = 'a -> 'a Iter.t
   (** Given a counter-example, return an iterator on smaller versions


### PR DESCRIPTION
Fixes #219

This documents the `QCheck.Shrink` invariants both in the documentation's `QCheck` front page and in the `Shrink` sub-page.

Strictly speaking, returning the identity is a special case of not meeting a strictly decreasing termination measure.
As a QCheck shrinker author, it is however a common enough error I've also made myself, so I believe it is worth warning explicitly about.