### PR TITLE
Elaborate on QCheck/QCheck2 situation in README too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## NEXT RELEASE
 
+- Elaborate on `QCheck`/`QCheck2` situation in README
 - Add a missing `description` field to the *.opam files
 - Document `Shrink` invariants in the `QCheck` module
 - Fix a qcheck-ounit test suite failure on OCaml 5.4, removing a needless extra newline

--- a/README.adoc
+++ b/README.adoc
@@ -344,6 +344,12 @@ let test_buggy =
 QCheck_base_runner.run_tests [test_buggy];;
 ----
 
+Being newer the `QCheck2` module is less battle tested than `QCheck`.
+`QCheck2` on the other hand removes the need for having to hand-write shrinkers.
+`QCheck` tests can be ported to `QCheck2` by following the
+https://c-cube.github.io/qcheck/dev/qcheck-core/QCheck2/index.html#migration_qcheck2[migration guide].
+Please file an issue if you encounter problems using either of the two modules.
+
 
 === Preconditions
 


### PR DESCRIPTION
Fixes #186

PR #302 added a note about the `QCheck`/`QCheck2` situation to the `qcheck-core` documentation page.
This little PR adds a similar note to the front page README.
Together the two PRs document the situation for newcomers and occasional contributors as requested in #186.