### PR TITLE
Align printed `collect` statistics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## NEXT RELEASE
 
+- Align printed `collect` statistics and also add a percentage
 - Fix `QCheck{,2}.Gen.float` generator which would only generate numbers with an
   exponent between 2^{-21} and 2^22
 - Elaborate on `QCheck`/`QCheck2` situation in README

--- a/example/QCheck_runner_test.expected.ocaml4.32
+++ b/example/QCheck_runner_test.expected.ocaml4.32
@@ -19,11 +19,11 @@ exception Dune__exe__QCheck_runner_test.Error
 
 Collect results for test collect_results:
 
- 4:     20 cases (20.0%)
- 3:     25 cases (25.0%)
- 2:     17 cases (17.0%)
- 1:     18 cases (18.0%)
- 0:     20 cases (20.0%)
+ 3:     25 cases  (25.0%)
+ 4:     20 cases  (20.0%)
+ 0:     20 cases  (20.0%)
+ 1:     18 cases  (18.0%)
+ 2:     17 cases  (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/example/QCheck_runner_test.expected.ocaml4.32
+++ b/example/QCheck_runner_test.expected.ocaml4.32
@@ -19,11 +19,11 @@ exception Dune__exe__QCheck_runner_test.Error
 
 Collect results for test collect_results:
 
-4: 20 cases
-3: 25 cases
-2: 17 cases
-1: 18 cases
-0: 20 cases
+ 4:     20 cases (20.0%)
+ 3:     25 cases (25.0%)
+ 2:     17 cases (17.0%)
+ 1:     18 cases (18.0%)
+ 0:     20 cases (20.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/example/QCheck_runner_test.expected.ocaml4.64
+++ b/example/QCheck_runner_test.expected.ocaml4.64
@@ -19,11 +19,11 @@ exception Dune__exe__QCheck_runner_test.Error
 
 Collect results for test collect_results:
 
- 4:     20 cases (20.0%)
- 3:     25 cases (25.0%)
- 2:     17 cases (17.0%)
- 1:     18 cases (18.0%)
- 0:     20 cases (20.0%)
+ 3:     25 cases  (25.0%)
+ 4:     20 cases  (20.0%)
+ 0:     20 cases  (20.0%)
+ 1:     18 cases  (18.0%)
+ 2:     17 cases  (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/example/QCheck_runner_test.expected.ocaml4.64
+++ b/example/QCheck_runner_test.expected.ocaml4.64
@@ -19,11 +19,11 @@ exception Dune__exe__QCheck_runner_test.Error
 
 Collect results for test collect_results:
 
-4: 20 cases
-3: 25 cases
-2: 17 cases
-1: 18 cases
-0: 20 cases
+ 4:     20 cases (20.0%)
+ 3:     25 cases (25.0%)
+ 2:     17 cases (17.0%)
+ 1:     18 cases (18.0%)
+ 0:     20 cases (20.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/example/QCheck_runner_test.expected.ocaml5.32
+++ b/example/QCheck_runner_test.expected.ocaml5.32
@@ -19,11 +19,11 @@ exception Dune__exe__QCheck_runner_test.Error
 
 Collect results for test collect_results:
 
-4: 24 cases
-3: 20 cases
-2: 18 cases
-1: 21 cases
-0: 17 cases
+ 4:     24 cases (24.0%)
+ 3:     20 cases (20.0%)
+ 2:     18 cases (18.0%)
+ 1:     21 cases (21.0%)
+ 0:     17 cases (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/example/QCheck_runner_test.expected.ocaml5.32
+++ b/example/QCheck_runner_test.expected.ocaml5.32
@@ -19,11 +19,11 @@ exception Dune__exe__QCheck_runner_test.Error
 
 Collect results for test collect_results:
 
- 4:     24 cases (24.0%)
- 3:     20 cases (20.0%)
- 2:     18 cases (18.0%)
- 1:     21 cases (21.0%)
- 0:     17 cases (17.0%)
+ 4:     24 cases  (24.0%)
+ 1:     21 cases  (21.0%)
+ 3:     20 cases  (20.0%)
+ 2:     18 cases  (18.0%)
+ 0:     17 cases  (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/example/QCheck_runner_test.expected.ocaml5.64
+++ b/example/QCheck_runner_test.expected.ocaml5.64
@@ -19,11 +19,11 @@ exception Dune__exe__QCheck_runner_test.Error
 
 Collect results for test collect_results:
 
-4: 24 cases
-3: 20 cases
-2: 18 cases
-1: 21 cases
-0: 17 cases
+ 4:     24 cases (24.0%)
+ 3:     20 cases (20.0%)
+ 2:     18 cases (18.0%)
+ 1:     21 cases (21.0%)
+ 0:     17 cases (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/example/QCheck_runner_test.expected.ocaml5.64
+++ b/example/QCheck_runner_test.expected.ocaml5.64
@@ -19,11 +19,11 @@ exception Dune__exe__QCheck_runner_test.Error
 
 Collect results for test collect_results:
 
- 4:     24 cases (24.0%)
- 3:     20 cases (20.0%)
- 2:     18 cases (18.0%)
- 1:     21 cases (21.0%)
- 0:     17 cases (17.0%)
+ 4:     24 cases  (24.0%)
+ 1:     21 cases  (21.0%)
+ 3:     20 cases  (20.0%)
+ 2:     18 cases  (18.0%)
+ 0:     17 cases  (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -2055,11 +2055,13 @@ module Test = struct
     let total,lab_len =
       Hashtbl.fold
         (fun case num (total,lab_len) -> (total+num, max lab_len (String.length case))) c (0,0) in
-    Hashtbl.iter
-      (fun case num ->
+    let sorted_cases = (* reverse compare yields decreasing order *)
+      Hashtbl.to_seq c |> List.of_seq |> List.sort (fun (_,n1) (_,n2) -> Int.compare n2 n1) in
+    List.iter
+      (fun (case,num) ->
          let percentage = 100. *. (float num) /. (float total) in (* Workaround for Windows/Unix difference: *)
          let percentage = (Float.round (10. *. percentage)) /. 10. in (* 100. *. 7525. /. 10000. -> 75.2 or 75.3 *)
-         Printf.bprintf out " %-*s %6d cases (%.1f%%)\n" (1+lab_len) (case ^ ":") num percentage) c ;
+         Printf.bprintf out " %-*s %6d cases (%.1f%%)\n" (1+lab_len) (case ^ ":") num percentage) sorted_cases;
     Buffer.contents out
 
   let stat_max_lines = 20 (* maximum number of lines for a histogram *)

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -2057,7 +2057,8 @@ module Test = struct
         (fun case num (total,lab_len) -> (total+num, max lab_len (String.length case))) c (0,0) in
     Hashtbl.iter
       (fun case num ->
-         let percentage = 100. *. (float num) /. (float total) in
+         let percentage = 100. *. (float num) /. (float total) in (* Workaround for Windows/Unix difference: *)
+         let percentage = (Float.round (10. *. percentage)) /. 10. in (* 100. *. 7525. /. 10000. -> 75.2 or 75.3 *)
          Printf.bprintf out " %-*s %6d cases (%.1f%%)\n" (1+lab_len) (case ^ ":") num percentage) c ;
     Buffer.contents out
 

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -2052,8 +2052,13 @@ module Test = struct
 
   let print_collect c =
     let out = Buffer.create 64 in
+    let total,lab_len =
+      Hashtbl.fold
+        (fun case num (total,lab_len) -> (total+num, max lab_len (String.length case))) c (0,0) in
     Hashtbl.iter
-      (fun case num -> Printf.bprintf out "%s: %d cases\n" case num) c;
+      (fun case num ->
+         let percentage = 100. *. (float num) /. (float total) in
+         Printf.bprintf out " %-*s %6d cases (%.1f%%)\n" (1+lab_len) (case ^ ":") num percentage) c ;
     Buffer.contents out
 
   let stat_max_lines = 20 (* maximum number of lines for a histogram *)

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -2061,7 +2061,8 @@ module Test = struct
       (fun (case,num) ->
          let percentage = 100. *. (float num) /. (float total) in (* Workaround for Windows/Unix difference: *)
          let percentage = (Float.round (10. *. percentage)) /. 10. in (* 100. *. 7525. /. 10000. -> 75.2 or 75.3 *)
-         Printf.bprintf out " %-*s %6d cases (%.1f%%)\n" (1+lab_len) (case ^ ":") num percentage) sorted_cases;
+         let perc_str = Printf.sprintf "(%.1f%%)" percentage in
+         Printf.bprintf out " %-*s %6d cases %8s\n" (1+lab_len) (case ^ ":") num perc_str) sorted_cases;
     Buffer.contents out
 
   let stat_max_lines = 20 (* maximum number of lines for a histogram *)

--- a/src/runner/QCheck_base_runner.mli
+++ b/src/runner/QCheck_base_runner.mli
@@ -182,11 +182,11 @@ Called from file "src/QCheck.ml", line 839, characters 13-33
 
 Collect results for test collect_results:
 
-4: 207 cases
-3: 190 cases
-2: 219 cases
-1: 196 cases
-0: 188 cases
+ 4:     207 cases (20.7%)
+ 3:     190 cases (19.0%)
+ 2:     219 cases (21.9%)
+ 1:     196 cases (19.6%)
+ 0:     188 cases (18.8%)
 
 ================================================================================
 failure (1 tests failed, 1 tests errored, ran 4 tests)

--- a/test/core/QCheck2_expect_test.expected.ocaml4.32
+++ b/test/core/QCheck2_expect_test.expected.ocaml4.32
@@ -138,11 +138,11 @@ exception QCheck2_tests.Overall.Error
 
 Collect results for test collect_results:
 
-4: 20 cases
-3: 25 cases
-2: 17 cases
-1: 18 cases
-0: 20 cases
+ 4:     20 cases (20.0%)
+ 3:     25 cases (25.0%)
+ 2:     17 cases (17.0%)
+ 1:     18 cases (18.0%)
+ 0:     20 cases (20.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -706,8 +706,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
-true: 250134 cases
-false: 249866 cases
+ true:  250134 cases (50.0%)
+ false: 249866 cases (50.0%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1146,15 +1146,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
-None  : 1519 cases
-Some _: 8481 cases
+ None:     1519 cases (15.2%)
+ Some _:   8481 cases (84.8%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
-Error _: 2577 cases
-Ok _   : 7423 cases
+ Error _:   2577 cases (25.8%)
+ Ok _:      7423 cases (74.2%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/test/core/QCheck2_expect_test.expected.ocaml4.32
+++ b/test/core/QCheck2_expect_test.expected.ocaml4.32
@@ -138,11 +138,11 @@ exception QCheck2_tests.Overall.Error
 
 Collect results for test collect_results:
 
- 4:     20 cases (20.0%)
- 3:     25 cases (25.0%)
- 2:     17 cases (17.0%)
- 1:     18 cases (18.0%)
- 0:     20 cases (20.0%)
+ 3:     25 cases  (25.0%)
+ 4:     20 cases  (20.0%)
+ 0:     20 cases  (20.0%)
+ 1:     18 cases  (18.0%)
+ 2:     17 cases  (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -706,8 +706,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
- true:  250134 cases (50.0%)
- false: 249866 cases (50.0%)
+ true:  250134 cases  (50.0%)
+ false: 249866 cases  (50.0%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1146,15 +1146,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
- None:     1519 cases (15.2%)
- Some _:   8481 cases (84.8%)
+ Some _:   8481 cases  (84.8%)
+ None:     1519 cases  (15.2%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
- Error _:   2577 cases (25.8%)
- Ok _:      7423 cases (74.2%)
+ Ok _:      7423 cases  (74.2%)
+ Error _:   2577 cases  (25.8%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1783,9 +1783,9 @@ stats significant:
 
 Collect results for test float classify:
 
-FP_normal: 4994 cases
-FP_nan: 2 cases
-FP_subnormal: 4 cases
+ FP_normal:      4994 cases  (99.9%)
+ FP_subnormal:      4 cases   (0.1%)
+ FP_nan:            2 cases   (0.0%)
 ================================================================================
 1 warning(s)
 failure (83 tests failed, 3 tests errored, ran 178 tests)

--- a/test/core/QCheck2_expect_test.expected.ocaml4.64
+++ b/test/core/QCheck2_expect_test.expected.ocaml4.64
@@ -200,11 +200,11 @@ exception QCheck2_tests.Overall.Error
 
 Collect results for test collect_results:
 
-4: 20 cases
-3: 25 cases
-2: 17 cases
-1: 18 cases
-0: 20 cases
+ 4:     20 cases (20.0%)
+ 3:     25 cases (25.0%)
+ 2:     17 cases (17.0%)
+ 1:     18 cases (18.0%)
+ 0:     20 cases (20.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -768,8 +768,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
-true: 250134 cases
-false: 249866 cases
+ true:  250134 cases (50.0%)
+ false: 249866 cases (50.0%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1208,15 +1208,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
-None  : 1519 cases
-Some _: 8481 cases
+ None:     1519 cases (15.2%)
+ Some _:   8481 cases (84.8%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
-Error _: 2577 cases
-Ok _   : 7423 cases
+ Error _:   2577 cases (25.8%)
+ Ok _:      7423 cases (74.2%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/test/core/QCheck2_expect_test.expected.ocaml4.64
+++ b/test/core/QCheck2_expect_test.expected.ocaml4.64
@@ -200,11 +200,11 @@ exception QCheck2_tests.Overall.Error
 
 Collect results for test collect_results:
 
- 4:     20 cases (20.0%)
- 3:     25 cases (25.0%)
- 2:     17 cases (17.0%)
- 1:     18 cases (18.0%)
- 0:     20 cases (20.0%)
+ 3:     25 cases  (25.0%)
+ 4:     20 cases  (20.0%)
+ 0:     20 cases  (20.0%)
+ 1:     18 cases  (18.0%)
+ 2:     17 cases  (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -768,8 +768,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
- true:  250134 cases (50.0%)
- false: 249866 cases (50.0%)
+ true:  250134 cases  (50.0%)
+ false: 249866 cases  (50.0%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1208,15 +1208,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
- None:     1519 cases (15.2%)
- Some _:   8481 cases (84.8%)
+ Some _:   8481 cases  (84.8%)
+ None:     1519 cases  (15.2%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
- Error _:   2577 cases (25.8%)
- Ok _:      7423 cases (74.2%)
+ Ok _:      7423 cases  (74.2%)
+ Error _:   2577 cases  (25.8%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1845,9 +1845,9 @@ stats significant:
 
 Collect results for test float classify:
 
-FP_normal: 4994 cases
-FP_nan: 2 cases
-FP_subnormal: 4 cases
+ FP_normal:      4994 cases  (99.9%)
+ FP_subnormal:      4 cases   (0.1%)
+ FP_nan:            2 cases   (0.0%)
 ================================================================================
 1 warning(s)
 failure (83 tests failed, 3 tests errored, ran 178 tests)

--- a/test/core/QCheck2_expect_test.expected.ocaml5.32
+++ b/test/core/QCheck2_expect_test.expected.ocaml5.32
@@ -1137,7 +1137,7 @@ Collect results for test option dist:
 Collect results for test result dist:
 
  Error _:   2475 cases (24.8%)
- Ok _:      7525 cases (75.2%)
+ Ok _:      7525 cases (75.3%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/test/core/QCheck2_expect_test.expected.ocaml5.32
+++ b/test/core/QCheck2_expect_test.expected.ocaml5.32
@@ -121,11 +121,11 @@ exception QCheck2_tests.Overall.Error
 
 Collect results for test collect_results:
 
- 4:     24 cases (24.0%)
- 3:     20 cases (20.0%)
- 2:     18 cases (18.0%)
- 1:     21 cases (21.0%)
- 0:     17 cases (17.0%)
+ 4:     24 cases  (24.0%)
+ 1:     21 cases  (21.0%)
+ 3:     20 cases  (20.0%)
+ 2:     18 cases  (18.0%)
+ 0:     17 cases  (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -689,8 +689,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
- true:  250511 cases (50.1%)
- false: 249489 cases (49.9%)
+ true:  250511 cases  (50.1%)
+ false: 249489 cases  (49.9%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1129,15 +1129,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
- None:     1481 cases (14.8%)
- Some _:   8519 cases (85.2%)
+ Some _:   8519 cases  (85.2%)
+ None:     1481 cases  (14.8%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
- Error _:   2475 cases (24.8%)
- Ok _:      7525 cases (75.3%)
+ Ok _:      7525 cases  (75.3%)
+ Error _:   2475 cases  (24.8%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1767,9 +1767,9 @@ stats significant:
 
 Collect results for test float classify:
 
-FP_normal: 4994 cases
-FP_nan: 3 cases
-FP_subnormal: 3 cases
+ FP_normal:      4994 cases  (99.9%)
+ FP_nan:            3 cases   (0.1%)
+ FP_subnormal:      3 cases   (0.1%)
 ================================================================================
 1 warning(s)
 failure (83 tests failed, 3 tests errored, ran 178 tests)

--- a/test/core/QCheck2_expect_test.expected.ocaml5.32
+++ b/test/core/QCheck2_expect_test.expected.ocaml5.32
@@ -121,11 +121,11 @@ exception QCheck2_tests.Overall.Error
 
 Collect results for test collect_results:
 
-4: 24 cases
-3: 20 cases
-2: 18 cases
-1: 21 cases
-0: 17 cases
+ 4:     24 cases (24.0%)
+ 3:     20 cases (20.0%)
+ 2:     18 cases (18.0%)
+ 1:     21 cases (21.0%)
+ 0:     17 cases (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -689,8 +689,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
-true: 250511 cases
-false: 249489 cases
+ true:  250511 cases (50.1%)
+ false: 249489 cases (49.9%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1129,15 +1129,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
-None  : 1481 cases
-Some _: 8519 cases
+ None:     1481 cases (14.8%)
+ Some _:   8519 cases (85.2%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
-Error _: 2475 cases
-Ok _   : 7525 cases
+ Error _:   2475 cases (24.8%)
+ Ok _:      7525 cases (75.2%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/test/core/QCheck2_expect_test.expected.ocaml5.64
+++ b/test/core/QCheck2_expect_test.expected.ocaml5.64
@@ -1199,7 +1199,7 @@ Collect results for test option dist:
 Collect results for test result dist:
 
  Error _:   2475 cases (24.8%)
- Ok _:      7525 cases (75.2%)
+ Ok _:      7525 cases (75.3%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/test/core/QCheck2_expect_test.expected.ocaml5.64
+++ b/test/core/QCheck2_expect_test.expected.ocaml5.64
@@ -183,11 +183,11 @@ exception QCheck2_tests.Overall.Error
 
 Collect results for test collect_results:
 
-4: 24 cases
-3: 20 cases
-2: 18 cases
-1: 21 cases
-0: 17 cases
+ 4:     24 cases (24.0%)
+ 3:     20 cases (20.0%)
+ 2:     18 cases (18.0%)
+ 1:     21 cases (21.0%)
+ 0:     17 cases (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -751,8 +751,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
-true: 250511 cases
-false: 249489 cases
+ true:  250511 cases (50.1%)
+ false: 249489 cases (49.9%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1191,15 +1191,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
-None  : 1481 cases
-Some _: 8519 cases
+ None:     1481 cases (14.8%)
+ Some _:   8519 cases (85.2%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
-Error _: 2475 cases
-Ok _   : 7525 cases
+ Error _:   2475 cases (24.8%)
+ Ok _:      7525 cases (75.2%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/test/core/QCheck2_expect_test.expected.ocaml5.64
+++ b/test/core/QCheck2_expect_test.expected.ocaml5.64
@@ -183,11 +183,11 @@ exception QCheck2_tests.Overall.Error
 
 Collect results for test collect_results:
 
- 4:     24 cases (24.0%)
- 3:     20 cases (20.0%)
- 2:     18 cases (18.0%)
- 1:     21 cases (21.0%)
- 0:     17 cases (17.0%)
+ 4:     24 cases  (24.0%)
+ 1:     21 cases  (21.0%)
+ 3:     20 cases  (20.0%)
+ 2:     18 cases  (18.0%)
+ 0:     17 cases  (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -751,8 +751,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
- true:  250511 cases (50.1%)
- false: 249489 cases (49.9%)
+ true:  250511 cases  (50.1%)
+ false: 249489 cases  (49.9%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1191,15 +1191,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
- None:     1481 cases (14.8%)
- Some _:   8519 cases (85.2%)
+ Some _:   8519 cases  (85.2%)
+ None:     1481 cases  (14.8%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
- Error _:   2475 cases (24.8%)
- Ok _:      7525 cases (75.3%)
+ Ok _:      7525 cases  (75.3%)
+ Error _:   2475 cases  (24.8%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1829,9 +1829,9 @@ stats significant:
 
 Collect results for test float classify:
 
-FP_normal: 4994 cases
-FP_nan: 3 cases
-FP_subnormal: 3 cases
+ FP_normal:      4994 cases  (99.9%)
+ FP_nan:            3 cases   (0.1%)
+ FP_subnormal:      3 cases   (0.1%)
 ================================================================================
 1 warning(s)
 failure (83 tests failed, 3 tests errored, ran 178 tests)

--- a/test/core/QCheck2_tests.ml
+++ b/test/core/QCheck2_tests.ml
@@ -987,11 +987,11 @@ module Stats = struct
 
   let option_dist =
     Test.make ~name:"option dist" ~count:10_000
-      ~collect:(function None -> "None  " | Some _ -> "Some _") Gen.(option int) (fun _ -> true)
+      ~collect:(function None -> "None" | Some _ -> "Some _") Gen.(option int) (fun _ -> true)
 
   let result_dist =
     Test.make ~name:"result dist" ~count:10_000
-      ~collect:(function Ok _ -> "Ok _   " | Error _ -> "Error _") Gen.(result int string) (fun _ -> true)
+      ~collect:(function Ok _ -> "Ok _" | Error _ -> "Error _") Gen.(result int string) (fun _ -> true)
 
   let list_len_tests =
     let len = ("len",List.length) in

--- a/test/core/QCheck_expect_test.expected.ocaml4.32
+++ b/test/core/QCheck_expect_test.expected.ocaml4.32
@@ -114,11 +114,11 @@ exception QCheck_tests.Overall.Error
 
 Collect results for test collect_results:
 
- 4:     20 cases (20.0%)
- 3:     25 cases (25.0%)
- 2:     17 cases (17.0%)
- 1:     18 cases (18.0%)
- 0:     20 cases (20.0%)
+ 3:     25 cases  (25.0%)
+ 4:     20 cases  (20.0%)
+ 0:     20 cases  (20.0%)
+ 1:     18 cases  (18.0%)
+ 2:     17 cases  (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -682,8 +682,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
- true:  250134 cases (50.0%)
- false: 249866 cases (50.0%)
+ true:  250134 cases  (50.0%)
+ false: 249866 cases  (50.0%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1123,15 +1123,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
- None:     1489 cases (14.9%)
- Some _:   8511 cases (85.1%)
+ Some _:   8511 cases  (85.1%)
+ None:     1489 cases  (14.9%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
- Error _:   2523 cases (25.2%)
- Ok _:      7477 cases (74.8%)
+ Ok _:      7477 cases  (74.8%)
+ Error _:   2523 cases  (25.2%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1760,9 +1760,9 @@ stats significant:
 
 Collect results for test float classify:
 
-FP_normal: 4994 cases
-FP_nan: 2 cases
-FP_subnormal: 4 cases
+ FP_normal:      4994 cases  (99.9%)
+ FP_subnormal:      4 cases   (0.1%)
+ FP_nan:            2 cases   (0.0%)
 ================================================================================
 1 warning(s)
 failure (83 tests failed, 3 tests errored, ran 186 tests)

--- a/test/core/QCheck_expect_test.expected.ocaml4.32
+++ b/test/core/QCheck_expect_test.expected.ocaml4.32
@@ -114,11 +114,11 @@ exception QCheck_tests.Overall.Error
 
 Collect results for test collect_results:
 
-4: 20 cases
-3: 25 cases
-2: 17 cases
-1: 18 cases
-0: 20 cases
+ 4:     20 cases (20.0%)
+ 3:     25 cases (25.0%)
+ 2:     17 cases (17.0%)
+ 1:     18 cases (18.0%)
+ 0:     20 cases (20.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -682,8 +682,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
-true: 250134 cases
-false: 249866 cases
+ true:  250134 cases (50.0%)
+ false: 249866 cases (50.0%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1123,15 +1123,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
-None  : 1489 cases
-Some _: 8511 cases
+ None:     1489 cases (14.9%)
+ Some _:   8511 cases (85.1%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
-Error _: 2523 cases
-Ok _   : 7477 cases
+ Error _:   2523 cases (25.2%)
+ Ok _:      7477 cases (74.8%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/test/core/QCheck_expect_test.expected.ocaml4.64
+++ b/test/core/QCheck_expect_test.expected.ocaml4.64
@@ -146,11 +146,11 @@ exception QCheck_tests.Overall.Error
 
 Collect results for test collect_results:
 
- 4:     20 cases (20.0%)
- 3:     25 cases (25.0%)
- 2:     17 cases (17.0%)
- 1:     18 cases (18.0%)
- 0:     20 cases (20.0%)
+ 3:     25 cases  (25.0%)
+ 4:     20 cases  (20.0%)
+ 0:     20 cases  (20.0%)
+ 1:     18 cases  (18.0%)
+ 2:     17 cases  (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -714,8 +714,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
- true:  250134 cases (50.0%)
- false: 249866 cases (50.0%)
+ true:  250134 cases  (50.0%)
+ false: 249866 cases  (50.0%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1155,15 +1155,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
- None:     1500 cases (15.0%)
- Some _:   8500 cases (85.0%)
+ Some _:   8500 cases  (85.0%)
+ None:     1500 cases  (15.0%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
- Error _:   2554 cases (25.5%)
- Ok _:      7446 cases (74.5%)
+ Ok _:      7446 cases  (74.5%)
+ Error _:   2554 cases  (25.5%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1792,9 +1792,9 @@ stats significant:
 
 Collect results for test float classify:
 
-FP_normal: 4994 cases
-FP_nan: 2 cases
-FP_subnormal: 4 cases
+ FP_normal:      4994 cases  (99.9%)
+ FP_subnormal:      4 cases   (0.1%)
+ FP_nan:            2 cases   (0.0%)
 ================================================================================
 1 warning(s)
 failure (83 tests failed, 3 tests errored, ran 186 tests)

--- a/test/core/QCheck_expect_test.expected.ocaml4.64
+++ b/test/core/QCheck_expect_test.expected.ocaml4.64
@@ -146,11 +146,11 @@ exception QCheck_tests.Overall.Error
 
 Collect results for test collect_results:
 
-4: 20 cases
-3: 25 cases
-2: 17 cases
-1: 18 cases
-0: 20 cases
+ 4:     20 cases (20.0%)
+ 3:     25 cases (25.0%)
+ 2:     17 cases (17.0%)
+ 1:     18 cases (18.0%)
+ 0:     20 cases (20.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -714,8 +714,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
-true: 250134 cases
-false: 249866 cases
+ true:  250134 cases (50.0%)
+ false: 249866 cases (50.0%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1155,15 +1155,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
-None  : 1500 cases
-Some _: 8500 cases
+ None:     1500 cases (15.0%)
+ Some _:   8500 cases (85.0%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
-Error _: 2554 cases
-Ok _   : 7446 cases
+ Error _:   2554 cases (25.5%)
+ Ok _:      7446 cases (74.5%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/test/core/QCheck_expect_test.expected.ocaml5.32
+++ b/test/core/QCheck_expect_test.expected.ocaml5.32
@@ -124,11 +124,11 @@ exception QCheck_tests.Overall.Error
 
 Collect results for test collect_results:
 
- 4:     24 cases (24.0%)
- 3:     20 cases (20.0%)
- 2:     18 cases (18.0%)
- 1:     21 cases (21.0%)
- 0:     17 cases (17.0%)
+ 4:     24 cases  (24.0%)
+ 1:     21 cases  (21.0%)
+ 3:     20 cases  (20.0%)
+ 2:     18 cases  (18.0%)
+ 0:     17 cases  (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -692,8 +692,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
- true:  250511 cases (50.1%)
- false: 249489 cases (49.9%)
+ true:  250511 cases  (50.1%)
+ false: 249489 cases  (49.9%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1133,15 +1133,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
- None:     1492 cases (14.9%)
- Some _:   8508 cases (85.1%)
+ Some _:   8508 cases  (85.1%)
+ None:     1492 cases  (14.9%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
- Error _:   2439 cases (24.4%)
- Ok _:      7561 cases (75.6%)
+ Ok _:      7561 cases  (75.6%)
+ Error _:   2439 cases  (24.4%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1771,9 +1771,9 @@ stats significant:
 
 Collect results for test float classify:
 
-FP_normal: 4994 cases
-FP_nan: 3 cases
-FP_subnormal: 3 cases
+ FP_normal:      4994 cases  (99.9%)
+ FP_nan:            3 cases   (0.1%)
+ FP_subnormal:      3 cases   (0.1%)
 ================================================================================
 1 warning(s)
 failure (83 tests failed, 3 tests errored, ran 186 tests)

--- a/test/core/QCheck_expect_test.expected.ocaml5.32
+++ b/test/core/QCheck_expect_test.expected.ocaml5.32
@@ -124,11 +124,11 @@ exception QCheck_tests.Overall.Error
 
 Collect results for test collect_results:
 
-4: 24 cases
-3: 20 cases
-2: 18 cases
-1: 21 cases
-0: 17 cases
+ 4:     24 cases (24.0%)
+ 3:     20 cases (20.0%)
+ 2:     18 cases (18.0%)
+ 1:     21 cases (21.0%)
+ 0:     17 cases (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -692,8 +692,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
-true: 250511 cases
-false: 249489 cases
+ true:  250511 cases (50.1%)
+ false: 249489 cases (49.9%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1133,15 +1133,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
-None  : 1492 cases
-Some _: 8508 cases
+ None:     1492 cases (14.9%)
+ Some _:   8508 cases (85.1%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
-Error _: 2439 cases
-Ok _   : 7561 cases
+ Error _:   2439 cases (24.4%)
+ Ok _:      7561 cases (75.6%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/test/core/QCheck_expect_test.expected.ocaml5.64
+++ b/test/core/QCheck_expect_test.expected.ocaml5.64
@@ -156,11 +156,11 @@ exception QCheck_tests.Overall.Error
 
 Collect results for test collect_results:
 
-4: 24 cases
-3: 20 cases
-2: 18 cases
-1: 21 cases
-0: 17 cases
+ 4:     24 cases (24.0%)
+ 3:     20 cases (20.0%)
+ 2:     18 cases (18.0%)
+ 1:     21 cases (21.0%)
+ 0:     17 cases (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -724,8 +724,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
-true: 250511 cases
-false: 249489 cases
+ true:  250511 cases (50.1%)
+ false: 249489 cases (49.9%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1165,15 +1165,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
-None  : 1464 cases
-Some _: 8536 cases
+ None:     1464 cases (14.6%)
+ Some _:   8536 cases (85.4%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
-Error _: 2509 cases
-Ok _   : 7491 cases
+ Error _:   2509 cases (25.1%)
+ Ok _:      7491 cases (74.9%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/test/core/QCheck_expect_test.expected.ocaml5.64
+++ b/test/core/QCheck_expect_test.expected.ocaml5.64
@@ -156,11 +156,11 @@ exception QCheck_tests.Overall.Error
 
 Collect results for test collect_results:
 
- 4:     24 cases (24.0%)
- 3:     20 cases (20.0%)
- 2:     18 cases (18.0%)
- 1:     21 cases (21.0%)
- 0:     17 cases (17.0%)
+ 4:     24 cases  (24.0%)
+ 1:     21 cases  (21.0%)
+ 3:     20 cases  (20.0%)
+ 2:     18 cases  (18.0%)
+ 0:     17 cases  (17.0%)
 
 +++ Stats for with_stats ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -724,8 +724,8 @@ Backtrace:
 
 Collect results for test bool dist:
 
- true:  250511 cases (50.1%)
- false: 249489 cases (49.9%)
+ true:  250511 cases  (50.1%)
+ false: 249489 cases  (49.9%)
 
 +++ Stats for char code dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1165,15 +1165,15 @@ stats ordered pair sum:
 
 Collect results for test option dist:
 
- None:     1464 cases (14.6%)
- Some _:   8536 cases (85.4%)
+ Some _:   8536 cases  (85.4%)
+ None:     1464 cases  (14.6%)
 
 +++ Collect ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 Collect results for test result dist:
 
- Error _:   2509 cases (25.1%)
- Ok _:      7491 cases (74.9%)
+ Ok _:      7491 cases  (74.9%)
+ Error _:   2509 cases  (25.1%)
 
 +++ Stats for list len dist ++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
@@ -1803,9 +1803,9 @@ stats significant:
 
 Collect results for test float classify:
 
-FP_normal: 4994 cases
-FP_nan: 3 cases
-FP_subnormal: 3 cases
+ FP_normal:      4994 cases  (99.9%)
+ FP_nan:            3 cases   (0.1%)
+ FP_subnormal:      3 cases   (0.1%)
 ================================================================================
 1 warning(s)
 failure (83 tests failed, 3 tests errored, ran 186 tests)

--- a/test/core/QCheck_tests.ml
+++ b/test/core/QCheck_tests.ml
@@ -1053,11 +1053,11 @@ module Stats = struct
 
   let option_dist =
     Test.make ~name:"option dist" ~count:10_000
-      (set_collect (function None -> "None  " | Some _ -> "Some _") (option int)) (fun _ -> true)
+      (set_collect (function None -> "None" | Some _ -> "Some _") (option int)) (fun _ -> true)
 
   let result_dist =
     Test.make ~name:"result dist" ~count:10_000
-      (set_collect (function Ok _ -> "Ok _   " | Error _ -> "Error _") (result int string)) (fun _ -> true)
+      (set_collect (function Ok _ -> "Ok _" | Error _ -> "Error _") (result int string)) (fun _ -> true)
 
   let list_len_tests =
     let len = ("len",List.length) in


### PR DESCRIPTION
The `collect` statistics are nice for grouping things by `string`s, however without manually adding spaces to align them they appear sub-optimal:
```
Collect results for test option dist:

None: 1519 cases
Some _: 8481 cases
```

This PR aligns the printed labels and counts under each other, and throws a quick percentage in on top: 
```
Collect results for test option dist:

 None:     1519 cases (15.2%)
 Some _:   8481 cases (84.8%)
```

Overall this results in a nicer `collect` stats output :slightly_smiling_face: :sparkles: 