### PR TITLE
Fix 404 bug-reports link in ppx_deriving_qcheck.opam

### DIFF
--- a/ppx_deriving_qcheck.opam
+++ b/ppx_deriving_qcheck.opam
@@ -31,6 +31,6 @@ build: [
 ]
 
 homepage: "https://github.com/c-cube/qcheck/"
-bug-reports: "https://github.com/c-cube/qcheck/-/issues"
+bug-reports: "https://github.com/c-cube/qcheck/issues"
 dev-repo: "git+https://github.com/c-cube/qcheck.git"
 x-maintenance-intent: ["(latest)"]


### PR DESCRIPTION
Spotted on the rendered version at https://opam.ocaml.org/packages/ppx_deriving_qcheck/ 