### PR TITLE
Small fixes for OxCaml

### DIFF
--- a/src/core/QCheck.ml
+++ b/src/core/QCheck.ml
@@ -1263,7 +1263,7 @@ let small_list a = mk_list a (Gen.small_list a.gen)
 let array_sum_ f a = Array.fold_left (fun acc x -> f x+acc) 0 a
 
 let array a =
-  let small = _opt_map_or ~d:Array.length ~f:array_sum_ a.small in
+  let small x = _opt_map_or ~d:Array.length ~f:array_sum_ a.small x in
   make
     ~small
     ~shrink:(Shrink.array ?shrink:a.shrink)
@@ -1271,7 +1271,7 @@ let array a =
     (Gen.array a.gen)
 
 let array_of_size size a =
-  let small = _opt_map_or ~d:Array.length ~f:array_sum_ a.small in
+  let small x = _opt_map_or ~d:Array.length ~f:array_sum_ a.small x in
   make
     ~small
     ~shrink:(Shrink.array ?shrink:a.shrink)


### PR DESCRIPTION
Somehow, OxCaml does not like these partial applications:
```
File "src/core/QCheck.ml", line 1266, characters 45-55:
1266 |   let small = _opt_map_or ~d:Array.length ~f:array_sum_ a.small in
                                                    ^^^^^^^^^^
Error: This expression has type ('a -> int) -> 'a array -> int
       but an expression was expected of type
         ('a -> int) -> 'b array @ immutable -> int
       Type 'a array -> int is not compatible with type
         'b array @ immutable -> int
```