### PR TITLE
Remove duplicate printing from Alcotest backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,7 @@
   - `Observable.map`
   - `TestResult.stats` `TestResult.warnings` `TestResult.collect`
 - Clarify documentation for the `int*` and `nat*` generators
+- Disabled duplicated pretty-printed feedback when using `QCheck_alcotest` runner
 
 
 ## 0.91 (2025-12-21)

--- a/example/alcotest/QCheck_alcotest_test.expected.ocaml4.32
+++ b/example/alcotest/QCheck_alcotest_test.expected.ocaml4.32
@@ -12,15 +12,11 @@ Testing `my test'.
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              1   fail_sort_id.                           │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 11 shrink steps)
 [exception] test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 11 shrink steps)
  ──────────────────────────────────────────────────────────────────────────────
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              2   error_raise_exn.                        │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `error_raise_exn`
-raised exception `Error`
-on `0 (after 31 shrink steps)`
 [exception] test `error_raise_exn`
 raised exception `Error`
 on `0 (after 31 shrink steps)`
@@ -28,15 +24,11 @@ on `0 (after 31 shrink steps)`
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              4   neg test unexpected success.            │
 └──────────────────────────────────────────────────────────────────────────────┘
-negative test 'neg test unexpected success' succeeded unexpectedly
 [exception] negative test `neg test unexpected success` succeeded unexpectedly
  ──────────────────────────────────────────────────────────────────────────────
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              5   neg fail with error.                    │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `neg fail with error`
-raised exception `Error`
-on `0 (after 7 shrink steps)`
 [exception] test `neg fail with error`
 raised exception `Error`
 on `0 (after 7 shrink steps)`
@@ -44,12 +36,6 @@ on `0 (after 7 shrink steps)`
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              6   fail_check_err_message.                 │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `fail_check_err_message` failed on ≥ 1 cases:
-0 (after 7 shrink steps)
-this
-will
-always
-fail
 [exception] test `fail_check_err_message` failed on ≥ 1 cases:
 0 (after 7 shrink steps)
 this
@@ -73,7 +59,6 @@ Test debug_shrink successfully shrunk counter example (step 2) to:
 Test debug_shrink successfully shrunk counter example (step 3) to:
 (1, 0)
 law debug_shrink: 2 relevant cases (2 total)
-test `debug_shrink` failed on ≥ 1 cases: (1, 0) (after 3 shrink steps)
 [exception] test `debug_shrink` failed on ≥ 1 cases: (1, 0) (after 3 shrink steps)
  ──────────────────────────────────────────────────────────────────────────────
 6 failures! 9 tests run.

--- a/example/alcotest/QCheck_alcotest_test.expected.ocaml4.64
+++ b/example/alcotest/QCheck_alcotest_test.expected.ocaml4.64
@@ -12,15 +12,11 @@ Testing `my test'.
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              1   fail_sort_id.                           │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 11 shrink steps)
 [exception] test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 11 shrink steps)
  ──────────────────────────────────────────────────────────────────────────────
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              2   error_raise_exn.                        │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `error_raise_exn`
-raised exception `Error`
-on `0 (after 63 shrink steps)`
 [exception] test `error_raise_exn`
 raised exception `Error`
 on `0 (after 63 shrink steps)`
@@ -28,15 +24,11 @@ on `0 (after 63 shrink steps)`
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              4   neg test unexpected success.            │
 └──────────────────────────────────────────────────────────────────────────────┘
-negative test 'neg test unexpected success' succeeded unexpectedly
 [exception] negative test `neg test unexpected success` succeeded unexpectedly
  ──────────────────────────────────────────────────────────────────────────────
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              5   neg fail with error.                    │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `neg fail with error`
-raised exception `Error`
-on `0 (after 7 shrink steps)`
 [exception] test `neg fail with error`
 raised exception `Error`
 on `0 (after 7 shrink steps)`
@@ -44,12 +36,6 @@ on `0 (after 7 shrink steps)`
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              6   fail_check_err_message.                 │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `fail_check_err_message` failed on ≥ 1 cases:
-0 (after 7 shrink steps)
-this
-will
-always
-fail
 [exception] test `fail_check_err_message` failed on ≥ 1 cases:
 0 (after 7 shrink steps)
 this
@@ -73,7 +59,6 @@ Test debug_shrink successfully shrunk counter example (step 2) to:
 Test debug_shrink successfully shrunk counter example (step 3) to:
 (1, 0)
 law debug_shrink: 2 relevant cases (2 total)
-test `debug_shrink` failed on ≥ 1 cases: (1, 0) (after 3 shrink steps)
 [exception] test `debug_shrink` failed on ≥ 1 cases: (1, 0) (after 3 shrink steps)
  ──────────────────────────────────────────────────────────────────────────────
 6 failures! 9 tests run.

--- a/example/alcotest/QCheck_alcotest_test.expected.ocaml5.32
+++ b/example/alcotest/QCheck_alcotest_test.expected.ocaml5.32
@@ -12,15 +12,11 @@ Testing `my test'.
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              1   fail_sort_id.                           │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 16 shrink steps)
 [exception] test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 16 shrink steps)
  ──────────────────────────────────────────────────────────────────────────────
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              2   error_raise_exn.                        │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `error_raise_exn`
-raised exception `Error`
-on `0 (after 30 shrink steps)`
 [exception] test `error_raise_exn`
 raised exception `Error`
 on `0 (after 30 shrink steps)`
@@ -28,15 +24,11 @@ on `0 (after 30 shrink steps)`
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              4   neg test unexpected success.            │
 └──────────────────────────────────────────────────────────────────────────────┘
-negative test 'neg test unexpected success' succeeded unexpectedly
 [exception] negative test `neg test unexpected success` succeeded unexpectedly
  ──────────────────────────────────────────────────────────────────────────────
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              5   neg fail with error.                    │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `neg fail with error`
-raised exception `Error`
-on `0 (after 7 shrink steps)`
 [exception] test `neg fail with error`
 raised exception `Error`
 on `0 (after 7 shrink steps)`
@@ -44,12 +36,6 @@ on `0 (after 7 shrink steps)`
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              6   fail_check_err_message.                 │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `fail_check_err_message` failed on ≥ 1 cases:
-0 (after 7 shrink steps)
-this
-will
-always
-fail
 [exception] test `fail_check_err_message` failed on ≥ 1 cases:
 0 (after 7 shrink steps)
 this
@@ -76,7 +62,6 @@ Test debug_shrink successfully shrunk counter example (step 3) to:
 Test debug_shrink successfully shrunk counter example (step 4) to:
 (0, 1)
 law debug_shrink: 1 relevant cases (1 total)
-test `debug_shrink` failed on ≥ 1 cases: (0, 1) (after 4 shrink steps)
 [exception] test `debug_shrink` failed on ≥ 1 cases: (0, 1) (after 4 shrink steps)
  ──────────────────────────────────────────────────────────────────────────────
 6 failures! 9 tests run.

--- a/example/alcotest/QCheck_alcotest_test.expected.ocaml5.64
+++ b/example/alcotest/QCheck_alcotest_test.expected.ocaml5.64
@@ -12,15 +12,11 @@ Testing `my test'.
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              1   fail_sort_id.                           │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 16 shrink steps)
 [exception] test `fail_sort_id` failed on ≥ 1 cases: [1; 0] (after 16 shrink steps)
  ──────────────────────────────────────────────────────────────────────────────
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              2   error_raise_exn.                        │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `error_raise_exn`
-raised exception `Error`
-on `0 (after 62 shrink steps)`
 [exception] test `error_raise_exn`
 raised exception `Error`
 on `0 (after 62 shrink steps)`
@@ -28,15 +24,11 @@ on `0 (after 62 shrink steps)`
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              4   neg test unexpected success.            │
 └──────────────────────────────────────────────────────────────────────────────┘
-negative test 'neg test unexpected success' succeeded unexpectedly
 [exception] negative test `neg test unexpected success` succeeded unexpectedly
  ──────────────────────────────────────────────────────────────────────────────
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              5   neg fail with error.                    │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `neg fail with error`
-raised exception `Error`
-on `0 (after 7 shrink steps)`
 [exception] test `neg fail with error`
 raised exception `Error`
 on `0 (after 7 shrink steps)`
@@ -44,12 +36,6 @@ on `0 (after 7 shrink steps)`
 ┌──────────────────────────────────────────────────────────────────────────────┐
 │ [FAIL]        suite              6   fail_check_err_message.                 │
 └──────────────────────────────────────────────────────────────────────────────┘
-test `fail_check_err_message` failed on ≥ 1 cases:
-0 (after 7 shrink steps)
-this
-will
-always
-fail
 [exception] test `fail_check_err_message` failed on ≥ 1 cases:
 0 (after 7 shrink steps)
 this
@@ -76,7 +62,6 @@ Test debug_shrink successfully shrunk counter example (step 3) to:
 Test debug_shrink successfully shrunk counter example (step 4) to:
 (0, 1)
 law debug_shrink: 1 relevant cases (1 total)
-test `debug_shrink` failed on ≥ 1 cases: (0, 1) (after 4 shrink steps)
 [exception] test `debug_shrink` failed on ≥ 1 cases: (0, 1) (after 4 shrink steps)
  ──────────────────────────────────────────────────────────────────────────────
 6 failures! 9 tests run.

--- a/src/alcotest/QCheck_alcotest.ml
+++ b/src/alcotest/QCheck_alcotest.ml
@@ -53,7 +53,7 @@ let to_alcotest
   let print = Raw.print_std in
   let name = T.get_name cell in
   let run () =
-    let call = Raw.callback ~colors ~verbose ~print_res:true ~print in
+    let call = Raw.callback ~colors ~verbose ~print_res:false ~print in
     T.check_cell_exn ~long ~call ~handler ~rand cell
   in
   ((name, speed_level, run) : unit Alcotest.test_case)


### PR DESCRIPTION
Hi, I noticed that when using the `Alcotest` backend for `QCheck`, there is duplicated output pretty printer output on test failures - one set from `Alcotest` and one set from `QCheck`. 

I believe a similar issue is mentioned in #103. I think I have corrected this issue in this PR, however, I would love a maintainer to sanity check me, as I'm not incredibly familiar with the `QCheck` codebase.

Thanks!