### PR TITLE
Document the ppx `@weight` attribute

### DIFF
--- a/src/ppx_deriving_qcheck/README.md
+++ b/src/ppx_deriving_qcheck/README.md
@@ -242,6 +242,28 @@ let gen_color =
      (1, (QCheck.Gen.pure `Green))] : color QCheck.Gen.t)
 ```
 
+### Overwrite weights
+
+If you wan't to specify your own weigth for one of the variants, you can
+add an attribute to the type.
+
+For instance, the following will never generate any `Blue` variant:
+```ocaml
+type color =
+  | Red
+  | Blue [@weight 0]
+  | Green
+[@@deriving qcheck]
+
+(* ==> *)
+
+let gen_color =
+  QCheck.Gen.oneof_weighted
+    [(1, (QCheck.Gen.pure Red));
+     (0, (QCheck.Gen.pure Blue));
+     (1, (QCheck.Gen.pure Green))]
+```
+
 ## Recursive variants
 * Recursive variants
 ```ocaml

--- a/src/ppx_deriving_qcheck/README.md
+++ b/src/ppx_deriving_qcheck/README.md
@@ -244,7 +244,7 @@ let gen_color =
 
 ### Overwrite weights
 
-If you wan't to specify your own weigth for one of the variants, you can
+If you wan't to specify your own weight for one of the variants, you can
 add an attribute to the type.
 
 For instance, the following will never generate any `Blue` variant:

--- a/src/ppx_deriving_qcheck/README.md
+++ b/src/ppx_deriving_qcheck/README.md
@@ -244,7 +244,7 @@ let gen_color =
 
 ### Overwrite weights
 
-If you wan't to specify your own weight for one of the variants, you can
+If you want to specify your own weight for one of the variants, you can
 add an attribute to the type.
 
 For instance, the following will never generate any `Blue` variant:

--- a/src/ppx_deriving_qcheck/README.md
+++ b/src/ppx_deriving_qcheck/README.md
@@ -247,11 +247,11 @@ let gen_color =
 If you want to specify your own weight for one of the variants, you can
 add an attribute to the type.
 
-For instance, the following will never generate any `Blue` variant:
+For instance, the following will generate a `Blue` variant twice as often as a `Red` or `Green` variant:
 ```ocaml
 type color =
   | Red
-  | Blue [@weight 0]
+  | Blue [@weight 2]
   | Green
 [@@deriving qcheck]
 
@@ -260,7 +260,7 @@ type color =
 let gen_color =
   QCheck.Gen.oneof_weighted
     [(1, (QCheck.Gen.pure Red));
-     (0, (QCheck.Gen.pure Blue));
+     (2, (QCheck.Gen.pure Blue));
      (1, (QCheck.Gen.pure Green))]
 ```
 

--- a/src/ppx_deriving_qcheck/README.md
+++ b/src/ppx_deriving_qcheck/README.md
@@ -264,6 +264,8 @@ let gen_color =
      (1, (QCheck.Gen.pure Green))]
 ```
 
+The `weight` attribute can also be handy to disable generation of a variant by annotating it with `[@weight 0]`.
+
 ## Recursive variants
 * Recursive variants
 ```ocaml


### PR DESCRIPTION
I originally forked the repo to create a `[@ignore]` attribute to the PPX, and realised that the more general `[@weight 0]` was already implemented.

PS: qcheck is really awesome!