### PR TITLE
Add doc warning about ==> precedence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,7 @@
 - Clarify documentation for the `int*` and `nat*` generators
 - Disabled duplicated pretty-printed feedback when using `QCheck_alcotest` runner
 - Fixed the overflow bug when `~count > max_int - 200` affecting `Test.{make_cell,make,make_neg}` in both QCheck and QCheck2
+- Add a documentation warning about the precedence of `==>` to `QCheck` and `QCheck2`
 
 
 ## 0.91 (2025-12-21)

--- a/src/core/QCheck.mli
+++ b/src/core/QCheck.mli
@@ -90,6 +90,12 @@ val (==>) : bool -> bool -> bool
     better with {!Test.check_exn} and the likes, because they will know
     the precondition was not satisfied.).
 
+    {b Note}: [==>] inherits the precedence of OCaml's [=] operator,
+    {{:https://ocaml.org/manual/5.4/expr.html#ss:precedence-and-associativity}which is higher than the logical connectives [&&] and [||]}.
+    As a consequence OCaml will parse [a && b ==> c] as [a && (b ==> c)] - and
+    similarly for [||] - which is likely not the intention. Put explicit
+    parentheses [(a && b) ==> c] or use the {!assume} function to avoid this issue.
+
     {b WARNING}: this function should only be used in a property
     (see {!Test.make}), because it raises a special exception in case of
     failure of the first argument, to distinguish between failed test

--- a/src/core/QCheck2.mli
+++ b/src/core/QCheck2.mli
@@ -1610,6 +1610,12 @@ val (==>) : bool -> bool -> bool
     better with {!Test.check_exn} and the likes, because they will know
     the precondition was not satisfied.).
 
+    {b Note}: [==>] inherits the precedence of OCaml's [=] operator,
+    {{:https://ocaml.org/manual/5.4/expr.html#ss:precedence-and-associativity}which is higher than the logical connectives [&&] and [||]}.
+    As a consequence OCaml will parse [a && b ==> c] as [a && (b ==> c)] - and
+    similarly for [||] - which is likely not the intention. Put explicit
+    parentheses [(a && b) ==> c] or use the {!assume} function to avoid this issue.
+
     ⚠️ This function should only be used in a property
     (see {!Test.make}), because it raises a special exception in case of
     failure of the first argument, to distinguish between failed test


### PR DESCRIPTION
This PR adds documentation warnings about how the precedence of `==>` interacts badly with the logical connectives `&&` and `||`.

Fixes #407 