### PR TITLE
Bump CI lower bound to 4.11 as 4.08 has been retired from the opam-repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           - ubuntu-latest
           - windows-latest
         ocaml-compiler:
-          - "4.08"
+          - "4.11"
           - "4.12"
           - "4.14"
           - "5.0"
@@ -27,9 +27,9 @@ jobs:
           - "5.4"
         exclude:
           - os: macos-latest
-            ocaml-compiler: "4.08"
+            ocaml-compiler: "4.11"
           - os: windows-latest
-            ocaml-compiler: "4.08"
+            ocaml-compiler: "4.11"
           - os: windows-latest
             ocaml-compiler: "4.12"
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
(as it says on the tin)

Spotted on the CI run for #411 