### PR TITLE
Add Gen.dep_pair combinator for dependent pair generation

### DIFF
--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -733,6 +733,9 @@ module Gen = struct
 
   let pair (g1 : 'a t) (g2 : 'b t) : ('a * 'b) t = liftA2 (fun a b -> (a, b)) g1 g2
 
+  let dep_pair (g : 'a t) (f : 'a -> 'b t) : ('a * 'b) t =
+    g >>= fun x -> tup2 (pure x) (f x)
+
   let triple (g1 : 'a t) (g2 : 'b t) (g3 : 'c t) : ('a * 'b * 'c) t = (fun a b c -> (a, b, c)) <$> g1 <*> g2 <*> g3
 
   let quad (g1 : 'a t) (g2 : 'b t) (g3 : 'c t) (g4 : 'd t) : ('a * 'b * 'c * 'd) t =

--- a/src/core/QCheck2.ml
+++ b/src/core/QCheck2.ml
@@ -734,7 +734,7 @@ module Gen = struct
   let pair (g1 : 'a t) (g2 : 'b t) : ('a * 'b) t = liftA2 (fun a b -> (a, b)) g1 g2
 
   let dep_pair (g : 'a t) (f : 'a -> 'b t) : ('a * 'b) t =
-    g >>= fun x -> tup2 (pure x) (f x)
+    g >>= fun x -> pair (pure x) (f x)
 
   let triple (g1 : 'a t) (g2 : 'b t) (g3 : 'c t) : ('a * 'b * 'c) t = (fun a b c -> (a, b, c)) <$> g1 <*> g2 <*> g3
 

--- a/src/core/QCheck2.mli
+++ b/src/core/QCheck2.mli
@@ -718,6 +718,29 @@ module Gen : sig
       Shrinks on [gen1] and then [gen2].
   *)
 
+  val dep_pair : 'a t -> ('a -> 'b t) -> ('a * 'b) t
+  (** [dep_pair gen f] generates dependent pairs where the second element
+      depends on the first.
+
+      First generates a value [x] from [gen], then generates a value [y]
+      from [f x], and returns the pair [(x, y)].
+
+      This is useful for generating pairs with dependencies, such as an
+      array and a valid index into that array, without using {!assume} to
+      filter out invalid combinations.
+
+      Example:
+      {[
+        let array_index =
+          dep_pair
+            (array_size (int_range 1 100) nat_small)
+            (fun t -> int_bound (pred (Array.length t)))
+      ]}
+
+      Shrinks on the first element and then on the second element (given
+      the shrunk first element).
+  *)
+
   val triple : 'a t -> 'b t -> 'c t -> ('a * 'b * 'c) t
   (** [triple gen1 gen2 gen3] generates triples.
 

--- a/test/core/QCheck2_unit_tests.ml
+++ b/test/core/QCheck2_unit_tests.ml
@@ -583,10 +583,24 @@ module Gen = struct
     let b = nb > 400 && nb < 600 in
     Alcotest.(check bool) "Gen.option produces around 50% of Some" b true
 
+  let test_dep_pair_array_index () =
+    let array_index_gen =
+      Gen.dep_pair
+        (Gen.array_size (Gen.int_range 1 100) Gen.nat_small)
+        (fun arr -> Gen.int_bound (pred (Array.length arr)))
+    in
+    for _i = 0 to 1000 do
+      let (arr, idx) = Gen.generate1 array_index_gen in
+      let len = Array.length arr in
+      let valid = len >= 1 && idx >= 0 && idx < len in
+      Alcotest.(check bool) "dep_pair generates valid array-index pairs" valid true
+    done
+
   let tests =
     ("Gen", Alcotest.[
          test_case "option with default ratio" `Quick test_gen_option_default;
          test_case "option with custom ratio" `Quick test_gen_option_custom;
+         test_case "dep_pair generates valid dependent pairs" `Quick test_dep_pair_array_index;
        ])
 end
 


### PR DESCRIPTION
## Summary

- Adds `Gen.dep_pair : 'a t -> ('a -> 'b t) -> ('a * 'b) t` to QCheck2, which generates pairs where the second element depends on the first. This avoids the need to use `assume` to filter invalid combinations (e.g. generating an array and a valid index into it).
- Includes documentation with usage example and a test that verifies generated array-index pairs are always valid.

## Test plan

- [ ] `dune build` succeeds
- [ ] `dune runtest` passes, including the new `dep_pair` test in `QCheck2_unit_tests.ml`
- [ ] Verify the example in the `.mli` documentation compiles